### PR TITLE
Updates from Friday

### DIFF
--- a/python/.style.yapf
+++ b/python/.style.yapf
@@ -1,2 +1,2 @@
 [style]
-based_on_style = chromium
+based_on_style = google

--- a/python/examples/integration/integration_client.py
+++ b/python/examples/integration/integration_client.py
@@ -14,47 +14,48 @@ import command_line_pb2
 
 class FixedActiveSpanSource(ActiveSpanSource):
 
-  def __init__(self):
-    self.active_span = None
+    def __init__(self):
+        self.active_span = None
 
-  def get_active_span(self):
-    return self.active_span
+    def get_active_span(self):
+        return self.active_span
 
 
 def echo(tracer, active_span_source, stub):
-  with tracer.start_span('command_line_client_span') as span:
-    active_span_source.active_span = span
-    response = stub.Echo(command_line_pb2.CommandRequest(text='Hello, hello'))
-    print(response.text)
+    with tracer.start_span('command_line_client_span') as span:
+        active_span_source.active_span = span
+        response = stub.Echo(
+            command_line_pb2.CommandRequest(text='Hello, hello'))
+        print(response.text)
 
 
 def run():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--access_token', help='LightStep Access Token')
-  parser.add_argument(
-      '--log_payloads',
-      action='store_true',
-      help='log request/response objects to open-tracing spans')
-  args = parser.parse_args()
-  if not args.access_token:
-    print('You must specify access_token')
-    sys.exit(-1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    parser.add_argument(
+        '--log_payloads',
+        action='store_true',
+        help='log request/response objects to open-tracing spans')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
 
-  tracer = lightstep.Tracer(
-      component_name='integration-client', access_token=args.access_token)
-  active_span_source = FixedActiveSpanSource()
-  tracer_interceptor = open_tracing_client_interceptor(
-      tracer,
-      active_span_source=active_span_source,
-      log_payloads=args.log_payloads)
-  channel = grpc.insecure_channel('localhost:50051')
-  channel = intercept_channel(channel, tracer_interceptor)
-  stub = command_line_pb2.CommandLineStub(channel)
+    tracer = lightstep.Tracer(
+        component_name='integration-client', access_token=args.access_token)
+    active_span_source = FixedActiveSpanSource()
+    tracer_interceptor = open_tracing_client_interceptor(
+        tracer,
+        active_span_source=active_span_source,
+        log_payloads=args.log_payloads)
+    channel = grpc.insecure_channel('localhost:50051')
+    channel = intercept_channel(channel, tracer_interceptor)
+    stub = command_line_pb2.CommandLineStub(channel)
 
-  echo(tracer, active_span_source, stub)
+    echo(tracer, active_span_source, stub)
 
-  tracer.flush()
+    tracer.flush()
 
 
 if __name__ == '__main__':
-  run()
+    run()

--- a/python/examples/store/store_client.py
+++ b/python/examples/store/store_client.py
@@ -16,104 +16,109 @@ import store_pb2
 
 class CommandExecuter(object):
 
-  def __init__(self, stub):
-    self._stub = stub
+    def __init__(self, stub):
+        self._stub = stub
 
-  def _execute_rpc(self, method, via, timeout, request_or_iterator):
-    if via == 'future':
-      result = getattr(self._stub, method).future(request_or_iterator, timeout)
-      return result.result()
-    elif via == 'with_call':
-      return getattr(self._stub, method).with_call(request_or_iterator,
-                                                   timeout)[0]
-    else:
-      return getattr(self._stub, method)(request_or_iterator, timeout)
+    def _execute_rpc(self, method, via, timeout, request_or_iterator):
+        if via == 'future':
+            result = getattr(self._stub, method).future(request_or_iterator,
+                                                        timeout)
+            return result.result()
+        elif via == 'with_call':
+            return getattr(self._stub, method).with_call(request_or_iterator,
+                                                         timeout)[0]
+        else:
+            return getattr(self._stub, method)(request_or_iterator, timeout)
 
-  def do_stock_item(self, via, timeout, arguments):
-    if len(arguments) != 1:
-      print('must input a single item')
-      return
-    request = store_pb2.AddItemRequest(name=arguments[0])
-    self._execute_rpc('AddItem', via, timeout, request)
+    def do_stock_item(self, via, timeout, arguments):
+        if len(arguments) != 1:
+            print('must input a single item')
+            return
+        request = store_pb2.AddItemRequest(name=arguments[0])
+        self._execute_rpc('AddItem', via, timeout, request)
 
-  def do_stock_items(self, via, timeout, arguments):
-    if not arguments:
-      print('must input at least one item')
-      return
-    requests = [store_pb2.AddItemRequest(name=name) for name in arguments]
-    self._execute_rpc('AddItems', via, timeout, iter(requests))
+    def do_stock_items(self, via, timeout, arguments):
+        if not arguments:
+            print('must input at least one item')
+            return
+        requests = [store_pb2.AddItemRequest(name=name) for name in arguments]
+        self._execute_rpc('AddItems', via, timeout, iter(requests))
 
-  def do_sell_item(self, via, timeout, arguments):
-    if len(arguments) != 1:
-      print('must input a single item')
-      return
-    request = store_pb2.RemoveItemRequest(name=arguments[0])
-    response = self._execute_rpc('RemoveItem', via, timeout, request)
-    if not response.was_successful:
-      print('unable to sell')
+    def do_sell_item(self, via, timeout, arguments):
+        if len(arguments) != 1:
+            print('must input a single item')
+            return
+        request = store_pb2.RemoveItemRequest(name=arguments[0])
+        response = self._execute_rpc('RemoveItem', via, timeout, request)
+        if not response.was_successful:
+            print('unable to sell')
 
-  def do_sell_items(self, via, timeout, arguments):
-    if not arguments:
-      print('must input at least one item')
-      return
-    requests = [store_pb2.RemoveItemRequest(name=name) for name in arguments]
-    response = self._execute_rpc('RemoveItems', via, timeout, iter(requests))
-    if not response.was_successful:
-      print('unable to sell')
+    def do_sell_items(self, via, timeout, arguments):
+        if not arguments:
+            print('must input at least one item')
+            return
+        requests = [
+            store_pb2.RemoveItemRequest(name=name) for name in arguments
+        ]
+        response = self._execute_rpc('RemoveItems', via, timeout,
+                                     iter(requests))
+        if not response.was_successful:
+            print('unable to sell')
 
-  def do_inventory(self, via, timeout, arguments):
-    if arguments:
-      print('inventory does not take any arguments')
-      return
-    if via != 'functor':
-      print('inventory can only be called via functor')
-      return
-    request = store_pb2.Empty()
-    result = self._execute_rpc('ListInventory', via, timeout, request)
-    for query in result:
-      print(query.name, '\t', query.count)
+    def do_inventory(self, via, timeout, arguments):
+        if arguments:
+            print('inventory does not take any arguments')
+            return
+        if via != 'functor':
+            print('inventory can only be called via functor')
+            return
+        request = store_pb2.Empty()
+        result = self._execute_rpc('ListInventory', via, timeout, request)
+        for query in result:
+            print(query.name, '\t', query.count)
 
-  def do_query_item(self, via, timeout, arguments):
-    if len(arguments) != 1:
-      print('must input a single item')
-      return
-    request = store_pb2.QueryItemRequest(name=arguments[0])
-    query = self._execute_rpc('QueryQuantity', via, timeout, request)
-    print(query.name, '\t', query.count)
+    def do_query_item(self, via, timeout, arguments):
+        if len(arguments) != 1:
+            print('must input a single item')
+            return
+        request = store_pb2.QueryItemRequest(name=arguments[0])
+        query = self._execute_rpc('QueryQuantity', via, timeout, request)
+        print(query.name, '\t', query.count)
 
-  def do_query_items(self, via, timeout, arguments):
-    if not arguments:
-      print('must input at least one item')
-      return
-    if via != 'functor':
-      print('query_items can only be called via functor')
-      return
-    requests = [store_pb2.QueryItemRequest(name=name) for name in arguments]
-    result = self._execute_rpc('QueryQuantities', via, timeout, iter(requests))
-    for query in result:
-      print(query.name, '\t', query.count)
+    def do_query_items(self, via, timeout, arguments):
+        if not arguments:
+            print('must input at least one item')
+            return
+        if via != 'functor':
+            print('query_items can only be called via functor')
+            return
+        requests = [store_pb2.QueryItemRequest(name=name) for name in arguments]
+        result = self._execute_rpc('QueryQuantities', via, timeout,
+                                   iter(requests))
+        for query in result:
+            print(query.name, '\t', query.count)
 
 
 def execute_command(command_executer, command, arguments):
-  via = 'functor'
-  timeout = None
-  for argument_index in range(0, len(arguments), 2):
-    argument = arguments[argument_index]
-    if argument == '--via' and argument_index + 1 < len(arguments):
-      if via not in ('functor', 'with_call', 'future'):
-        print('invalid --via option')
-        return
-      via = arguments[argument_index + 1]
-    elif argument == '--timeout' and argument_index + 1 < len(arguments):
-      timeout = float(arguments[argument_index + 1])
-    else:
-      arguments = arguments[argument_index:]
-      break
+    via = 'functor'
+    timeout = None
+    for argument_index in range(0, len(arguments), 2):
+        argument = arguments[argument_index]
+        if argument == '--via' and argument_index + 1 < len(arguments):
+            if via not in ('functor', 'with_call', 'future'):
+                print('invalid --via option')
+                return
+            via = arguments[argument_index + 1]
+        elif argument == '--timeout' and argument_index + 1 < len(arguments):
+            timeout = float(arguments[argument_index + 1])
+        else:
+            arguments = arguments[argument_index:]
+            break
 
-  try:
-    getattr(command_executer, 'do_' + command)(via, timeout, arguments)
-  except AttributeError:
-    print('unknown command: \"%s\"' % command)
+    try:
+        getattr(command_executer, 'do_' + command)(via, timeout, arguments)
+    except AttributeError:
+        print('unknown command: \"%s\"' % command)
 
 
 INSTRUCTIONS = \
@@ -141,56 +146,56 @@ Example:
 
 
 def read_and_execute(command_executer):
-  print(INSTRUCTIONS)
-  while True:
-    try:
-      line = input('> ')
-      components = line.split()
-      if not components:
-        continue
-      command = components[0]
-      arguments = components[1:]
-      execute_command(command_executer, command, arguments)
-    except EOFError:
-      break
+    print(INSTRUCTIONS)
+    while True:
+        try:
+            line = input('> ')
+            components = line.split()
+            if not components:
+                continue
+            command = components[0]
+            arguments = components[1:]
+            execute_command(command_executer, command, arguments)
+        except EOFError:
+            break
 
 
 def run():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--access_token', help='LightStep Access Token')
-  parser.add_argument(
-      '--log_payloads',
-      action='store_true',
-      help='log request/response objects to open-tracing spans')
-  parser.add_argument(
-      '--include_grpc_tags',
-      action='store_true',
-      help='set gRPC-specific tags on spans')
-  args = parser.parse_args()
-  if not args.access_token:
-    print('You must specify access_token')
-    sys.exit(-1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    parser.add_argument(
+        '--log_payloads',
+        action='store_true',
+        help='log request/response objects to open-tracing spans')
+    parser.add_argument(
+        '--include_grpc_tags',
+        action='store_true',
+        help='set gRPC-specific tags on spans')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
 
-  tracer = lightstep.Tracer(
-      component_name='store-client', access_token=args.access_token)
-  traced_attributes = []
-  if args.include_grpc_tags:
-    traced_attributes = [
-        ClientRequestAttribute.HEADERS, ClientRequestAttribute.METHOD_TYPE,
-        ClientRequestAttribute.METHOD_NAME, ClientRequestAttribute.DEADLINE
-    ]
-  tracer_interceptor = open_tracing_client_interceptor(
-      tracer,
-      log_payloads=args.log_payloads,
-      traced_attributes=traced_attributes)
-  channel = grpc.insecure_channel('localhost:50051')
-  channel = intercept_channel(channel, tracer_interceptor)
-  stub = store_pb2.StoreStub(channel)
+    tracer = lightstep.Tracer(
+        component_name='store-client', access_token=args.access_token)
+    traced_attributes = []
+    if args.include_grpc_tags:
+        traced_attributes = [
+            ClientRequestAttribute.HEADERS, ClientRequestAttribute.METHOD_TYPE,
+            ClientRequestAttribute.METHOD_NAME, ClientRequestAttribute.DEADLINE
+        ]
+    tracer_interceptor = open_tracing_client_interceptor(
+        tracer,
+        log_payloads=args.log_payloads,
+        traced_attributes=traced_attributes)
+    channel = grpc.insecure_channel('localhost:50051')
+    channel = intercept_channel(channel, tracer_interceptor)
+    stub = store_pb2.StoreStub(channel)
 
-  read_and_execute(CommandExecuter(stub))
+    read_and_execute(CommandExecuter(stub))
 
-  tracer.flush()
+    tracer.flush()
 
 
 if __name__ == '__main__':
-  run()
+    run()

--- a/python/examples/store/store_client.py
+++ b/python/examples/store/store_client.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import sys
 import argparse
-from builtins import input
+from builtins import input, range
 
 import grpc
 import lightstep
@@ -97,7 +97,7 @@ class CommandExecuter(object):
 def execute_command(command_executer, command, arguments):
   via = 'functor'
   timeout = None
-  for argument_index in xrange(0, len(arguments), 2):
+  for argument_index in range(0, len(arguments), 2):
     argument = arguments[argument_index]
     if argument == '--via' and argument_index + 1 < len(arguments):
       if via not in ('functor', 'with_call', 'future'):

--- a/python/examples/store/store_server.py
+++ b/python/examples/store/store_server.py
@@ -22,92 +22,92 @@ _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
 class Store(store_pb2.StoreServicer):
 
-  def __init__(self):
-    self._inventory = defaultdict(int)
+    def __init__(self):
+        self._inventory = defaultdict(int)
 
-  def AddItem(self, request, context):
-    self._inventory[request.name] += 1
-    return store_pb2.Empty()
+    def AddItem(self, request, context):
+        self._inventory[request.name] += 1
+        return store_pb2.Empty()
 
-  def AddItems(self, request_iter, context):
-    for request in request_iter:
-      self._inventory[request.name] += 1
-    return store_pb2.Empty()
+    def AddItems(self, request_iter, context):
+        for request in request_iter:
+            self._inventory[request.name] += 1
+        return store_pb2.Empty()
 
-  def RemoveItem(self, request, context):
-    new_quantity = self._inventory[request.name] - 1
-    if new_quantity < 0:
-      return store_pb2.RemoveItemResponse(was_successful=False)
-    self._inventory[request.name] = new_quantity
-    return store_pb2.RemoveItemResponse(was_successful=True)
+    def RemoveItem(self, request, context):
+        new_quantity = self._inventory[request.name] - 1
+        if new_quantity < 0:
+            return store_pb2.RemoveItemResponse(was_successful=False)
+        self._inventory[request.name] = new_quantity
+        return store_pb2.RemoveItemResponse(was_successful=True)
 
-  def RemoveItems(self, request_iter, context):
-    response = store_pb2.RemoveItemResponse(was_successful=True)
-    for request in request_iter:
-      response = self.RemoveItem(request, context)
-      if not response.was_successful:
-        break
-    return response
+    def RemoveItems(self, request_iter, context):
+        response = store_pb2.RemoveItemResponse(was_successful=True)
+        for request in request_iter:
+            response = self.RemoveItem(request, context)
+            if not response.was_successful:
+                break
+        return response
 
-  def ListInventory(self, request, context):
-    for name, count in iteritems(self._inventory):
-      if not count:
-        continue
-      else:
-        yield store_pb2.QuantityResponse(name=name, count=count)
+    def ListInventory(self, request, context):
+        for name, count in iteritems(self._inventory):
+            if not count:
+                continue
+            else:
+                yield store_pb2.QuantityResponse(name=name, count=count)
 
-  def QueryQuantity(self, request, context):
-    count = self._inventory[request.name]
-    return store_pb2.QuantityResponse(name=request.name, count=count)
+    def QueryQuantity(self, request, context):
+        count = self._inventory[request.name]
+        return store_pb2.QuantityResponse(name=request.name, count=count)
 
-  def QueryQuantities(self, request_iter, context):
-    for request in request_iter:
-      count = self._inventory[request.name]
-      yield store_pb2.QuantityResponse(name=request.name, count=count)
+    def QueryQuantities(self, request_iter, context):
+        for request in request_iter:
+            count = self._inventory[request.name]
+            yield store_pb2.QuantityResponse(name=request.name, count=count)
 
 
 def serve():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--access_token', help='LightStep Access Token')
-  parser.add_argument(
-      '--log_payloads',
-      action='store_true',
-      help='log request/response objects to open-tracing spans')
-  parser.add_argument(
-      '--include_grpc_tags',
-      action='store_true',
-      help='set gRPC-specific tags on spans')
-  args = parser.parse_args()
-  if not args.access_token:
-    print('You must specify access_token')
-    sys.exit(-1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    parser.add_argument(
+        '--log_payloads',
+        action='store_true',
+        help='log request/response objects to open-tracing spans')
+    parser.add_argument(
+        '--include_grpc_tags',
+        action='store_true',
+        help='set gRPC-specific tags on spans')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
 
-  tracer = lightstep.Tracer(
-      component_name='store-server', access_token=args.access_token)
-  traced_attributes = []
-  if args.include_grpc_tags:
-    traced_attributes = [
-        ServerRequestAttribute.HEADERS, ServerRequestAttribute.METHOD_TYPE,
-        ServerRequestAttribute.METHOD_NAME, ServerRequestAttribute.DEADLINE
-    ]
-  tracer_interceptor = open_tracing_server_interceptor(
-      tracer,
-      log_payloads=args.log_payloads,
-      traced_attributes=traced_attributes)
-  server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-  server = intercept_server(server, tracer_interceptor)
+    tracer = lightstep.Tracer(
+        component_name='store-server', access_token=args.access_token)
+    traced_attributes = []
+    if args.include_grpc_tags:
+        traced_attributes = [
+            ServerRequestAttribute.HEADERS, ServerRequestAttribute.METHOD_TYPE,
+            ServerRequestAttribute.METHOD_NAME, ServerRequestAttribute.DEADLINE
+        ]
+    tracer_interceptor = open_tracing_server_interceptor(
+        tracer,
+        log_payloads=args.log_payloads,
+        traced_attributes=traced_attributes)
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    server = intercept_server(server, tracer_interceptor)
 
-  store_pb2.add_StoreServicer_to_server(Store(), server)
-  server.add_insecure_port('[::]:50051')
-  server.start()
-  try:
-    while True:
-      time.sleep(_ONE_DAY_IN_SECONDS)
-  except KeyboardInterrupt:
-    server.stop(0)
+    store_pb2.add_StoreServicer_to_server(Store(), server)
+    server.add_insecure_port('[::]:50051')
+    server.start()
+    try:
+        while True:
+            time.sleep(_ONE_DAY_IN_SECONDS)
+    except KeyboardInterrupt:
+        server.stop(0)
 
-  tracer.flush()
+    tracer.flush()
 
 
 if __name__ == '__main__':
-  serve()
+    serve()

--- a/python/examples/store/store_server.py
+++ b/python/examples/store/store_server.py
@@ -88,7 +88,7 @@ def serve():
   if args.include_grpc_tags:
     traced_attributes = [
         ServerRequestAttribute.HEADERS, ServerRequestAttribute.METHOD_TYPE,
-        ServerRequestAttribute.METHOD_NAME
+        ServerRequestAttribute.METHOD_NAME, ServerRequestAttribute.DEADLINE
     ]
   tracer_interceptor = open_tracing_server_interceptor(
       tracer,

--- a/python/examples/trivial/trivial_client.py
+++ b/python/examples/trivial/trivial_client.py
@@ -13,29 +13,29 @@ import command_line_pb2
 
 
 def run():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--access_token', help='LightStep Access Token')
-  parser.add_argument(
-      '--log_payloads',
-      action='store_true',
-      help='log request/response objects to open-tracing spans')
-  args = parser.parse_args()
-  if not args.access_token:
-    print('You must specify access_token')
-    sys.exit(-1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    parser.add_argument(
+        '--log_payloads',
+        action='store_true',
+        help='log request/response objects to open-tracing spans')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
 
-  tracer = lightstep.Tracer(
-      component_name='trivial-client', access_token=args.access_token)
-  tracer_interceptor = open_tracing_client_interceptor(
-      tracer, log_payloads=args.log_payloads)
-  channel = grpc.insecure_channel('localhost:50051')
-  channel = intercept_channel(channel, tracer_interceptor)
-  stub = command_line_pb2.CommandLineStub(channel)
-  response = stub.Echo(command_line_pb2.CommandRequest(text='Hello, hello'))
-  print(response.text)
+    tracer = lightstep.Tracer(
+        component_name='trivial-client', access_token=args.access_token)
+    tracer_interceptor = open_tracing_client_interceptor(
+        tracer, log_payloads=args.log_payloads)
+    channel = grpc.insecure_channel('localhost:50051')
+    channel = intercept_channel(channel, tracer_interceptor)
+    stub = command_line_pb2.CommandLineStub(channel)
+    response = stub.Echo(command_line_pb2.CommandRequest(text='Hello, hello'))
+    print(response.text)
 
-  tracer.flush()
+    tracer.flush()
 
 
 if __name__ == '__main__':
-  run()
+    run()

--- a/python/examples/trivial/trivial_server.py
+++ b/python/examples/trivial/trivial_server.py
@@ -18,41 +18,41 @@ _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
 class CommandLine(command_line_pb2.CommandLineServicer):
 
-  def Echo(self, request, context):
-    return command_line_pb2.CommandResponse(text=request.text)
+    def Echo(self, request, context):
+        return command_line_pb2.CommandResponse(text=request.text)
 
 
 def serve():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--access_token', help='LightStep Access Token')
-  parser.add_argument(
-      '--log_payloads',
-      action='store_true',
-      help='log request/response objects to open-tracing spans')
-  args = parser.parse_args()
-  if not args.access_token:
-    print('You must specify access_token')
-    sys.exit(-1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    parser.add_argument(
+        '--log_payloads',
+        action='store_true',
+        help='log request/response objects to open-tracing spans')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
 
-  tracer = lightstep.Tracer(
-      component_name='trivial-server', access_token=args.access_token)
-  server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    tracer = lightstep.Tracer(
+        component_name='trivial-server', access_token=args.access_token)
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
 
-  tracer_interceptor = open_tracing_server_interceptor(
-      tracer, log_payloads=args.log_payloads)
-  server = intercept_server(server, tracer_interceptor)
+    tracer_interceptor = open_tracing_server_interceptor(
+        tracer, log_payloads=args.log_payloads)
+    server = intercept_server(server, tracer_interceptor)
 
-  command_line_pb2.add_CommandLineServicer_to_server(CommandLine(), server)
-  server.add_insecure_port('[::]:50051')
-  server.start()
-  try:
-    while True:
-      time.sleep(_ONE_DAY_IN_SECONDS)
-  except KeyboardInterrupt:
-    server.stop(0)
+    command_line_pb2.add_CommandLineServicer_to_server(CommandLine(), server)
+    server.add_insecure_port('[::]:50051')
+    server.start()
+    try:
+        while True:
+            time.sleep(_ONE_DAY_IN_SECONDS)
+    except KeyboardInterrupt:
+        server.stop(0)
 
-  tracer.flush()
+    tracer.flush()
 
 
 if __name__ == '__main__':
-  serve()
+    serve()

--- a/python/grpc_opentracing/__init__.py
+++ b/python/grpc_opentracing/__init__.py
@@ -7,11 +7,11 @@ import grpc
 
 
 class ActiveSpanSource(six.with_metaclass(abc.ABCMeta)):
-  """Provides a way to access an the active span."""
+    """Provides a way to access an the active span."""
 
-  @abc.abstractmethod
-  def get_active_span(self):
-    """Identifies the active span.
+    @abc.abstractmethod
+    def get_active_span(self):
+        """Identifies the active span.
 
     Returns:
       An object that implements the opentracing.Span interface.
@@ -20,7 +20,7 @@ class ActiveSpanSource(six.with_metaclass(abc.ABCMeta)):
 
 @enum.unique
 class ClientRequestAttribute(enum.Enum):
-  """Optional tracing tags available on the invocation-side.
+    """Optional tracing tags available on the invocation-side.
 
   Attributes:
     HEADERS: The initial :term:`metadata`.
@@ -29,15 +29,15 @@ class ClientRequestAttribute(enum.Enum):
     DEADLINE: The length of time in seconds to wait for the computation to
       terminate or be cancelled.
   """
-  HEADERS = 0
-  METHOD_TYPE = 1
-  METHOD_NAME = 2
-  DEADLINE = 3
+    HEADERS = 0
+    METHOD_TYPE = 1
+    METHOD_NAME = 2
+    DEADLINE = 3
 
 
 @enum.unique
 class ServerRequestAttribute(enum.Enum):
-  """Optional tracing tags available on the service-side.
+    """Optional tracing tags available on the service-side.
 
   Attributes:
     HEADERS: The initial :term:`metadata`.
@@ -46,17 +46,17 @@ class ServerRequestAttribute(enum.Enum):
     DEADLINE: The length of time in seconds to wait for the computation to
       terminate or be cancelled.
   """
-  HEADERS = 0
-  METHOD_TYPE = 1
-  METHOD_NAME = 2
-  DEADLINE = 3
+    HEADERS = 0
+    METHOD_TYPE = 1
+    METHOD_NAME = 2
+    DEADLINE = 3
 
 
 def open_tracing_client_interceptor(tracer,
                                     active_span_source=None,
                                     log_payloads=False,
                                     traced_attributes=None):
-  """Creates an invocation-side interceptor that can be use with gRPC to add
+    """Creates an invocation-side interceptor that can be use with gRPC to add
     OpenTracing information.
 
   Args:
@@ -68,19 +68,19 @@ def open_tracing_client_interceptor(tracer,
   Returns:
     An invocation-side interceptor object.
   """
-  from grpc_opentracing import _client
-  if traced_attributes is None:
-    traced_attributes = set()
-  else:
-    traced_attributes = set(traced_attributes)
-  return _client.OpenTracingClientInterceptor(tracer, active_span_source,
-                                              log_payloads, traced_attributes)
+    from grpc_opentracing import _client
+    if traced_attributes is None:
+        traced_attributes = set()
+    else:
+        traced_attributes = set(traced_attributes)
+    return _client.OpenTracingClientInterceptor(tracer, active_span_source,
+                                                log_payloads, traced_attributes)
 
 
 def open_tracing_server_interceptor(tracer,
                                     log_payloads=False,
                                     traced_attributes=None):
-  """Creates a service-side interceptor that can be use with gRPC to add
+    """Creates a service-side interceptor that can be use with gRPC to add
     OpenTracing information.
 
   Args:
@@ -90,13 +90,13 @@ def open_tracing_server_interceptor(tracer,
   Returns:
     A service-side interceptor object.
   """
-  from grpc_opentracing import _server
-  if traced_attributes is None:
-    traced_attributes = set()
-  else:
-    traced_attributes = set(traced_attributes)
-  return _server.OpenTracingServerInterceptor(tracer, log_payloads,
-                                              traced_attributes)
+    from grpc_opentracing import _server
+    if traced_attributes is None:
+        traced_attributes = set()
+    else:
+        traced_attributes = set(traced_attributes)
+    return _server.OpenTracingServerInterceptor(tracer, log_payloads,
+                                                traced_attributes)
 
 
 ###################################  __all__  #################################

--- a/python/grpc_opentracing/__init__.py
+++ b/python/grpc_opentracing/__init__.py
@@ -32,6 +32,7 @@ class ClientRequestAttribute(enum.Enum):
   HEADERS = 0
   METHOD_TYPE = 1
   METHOD_NAME = 2
+  DEADLINE = 3
 
 
 @enum.unique
@@ -48,6 +49,7 @@ class ServerRequestAttribute(enum.Enum):
   HEADERS = 0
   METHOD_TYPE = 1
   METHOD_NAME = 2
+  DEADLINE = 3
 
 
 def open_tracing_client_interceptor(tracer,

--- a/python/grpc_opentracing/__init__.py
+++ b/python/grpc_opentracing/__init__.py
@@ -26,6 +26,8 @@ class ClientRequestAttribute(enum.Enum):
     HEADERS: The initial :term:`metadata`.
     METHOD_TYPE: Type of the method invoked.
     METHOD_NAME: Name of the method invoked.
+    DEADLINE: The length of time in seconds to wait for the computation to
+      terminate or be cancelled.
   """
   HEADERS = 0
   METHOD_TYPE = 1
@@ -40,6 +42,8 @@ class ServerRequestAttribute(enum.Enum):
     HEADERS: The initial :term:`metadata`.
     METHOD_TYPE: Type of the method invoked.
     METHOD_NAME: Name of the method invoked.
+    DEADLINE: The length of time in seconds to wait for the computation to
+      terminate or be cancelled.
   """
   HEADERS = 0
   METHOD_TYPE = 1

--- a/python/grpc_opentracing/__init__.py
+++ b/python/grpc_opentracing/__init__.py
@@ -13,9 +13,9 @@ class ActiveSpanSource(six.with_metaclass(abc.ABCMeta)):
   def get_active_span(self):
     """Identifies the active span.
 
-        Returns:
-          An object that implements the opentracing.Span interface.
-        """
+    Returns:
+      An object that implements the opentracing.Span interface.
+    """
 
 
 @enum.unique
@@ -57,15 +57,15 @@ def open_tracing_client_interceptor(tracer,
   """Creates a client-side interceptor that can be use with gRPC to add
          OpenTracing information.
 
-    Args:
-      tracer: An object implmenting the opentracing.Tracer interface.
-      active_span_source: An optional ActiveSpanSource to customize how the
-        active span is determined.
-      log_payloads: Indicates whether requests should be logged.
+  Args:
+    tracer: An object implmenting the opentracing.Tracer interface.
+    active_span_source: An optional ActiveSpanSource to customize how the
+      active span is determined.
+    log_payloads: Indicates whether requests should be logged.
 
-    Returns:
-      A client-side interceptor object.
-    """
+  Returns:
+    A client-side interceptor object.
+  """
   from grpc_opentracing import _client
   if traced_attributes is None:
     traced_attributes = set()
@@ -81,13 +81,13 @@ def open_tracing_server_interceptor(tracer,
   """Creates a server-side interceptor that can be use with gRPC to add
          OpenTracing information.
 
-    Args:
-      tracer: An object implmenting the opentracing.Tracer interface.
-      log_payloads: Indicates whether requests should be logged.
+  Args:
+    tracer: An object implmenting the opentracing.Tracer interface.
+    log_payloads: Indicates whether requests should be logged.
 
-    Returns:
-      A server-side interceptor object.
-    """
+  Returns:
+    A server-side interceptor object.
+  """
   from grpc_opentracing import _server
   if traced_attributes is None:
     traced_attributes = set()

--- a/python/grpc_opentracing/__init__.py
+++ b/python/grpc_opentracing/__init__.py
@@ -1,4 +1,5 @@
 import abc
+import enum
 
 import six
 
@@ -17,9 +18,38 @@ class ActiveSpanSource(six.with_metaclass(abc.ABCMeta)):
         """
 
 
+@enum.unique
+class ClientRequestAttribute(enum.Enum):
+  """Optional tracing tags available on the client-side.
+
+  Attributes:
+    HEADERS: The initial :term:`metadata`.
+    METHOD_TYPE: Type of the method invoked.
+    METHOD_NAME: Name of the method invoked.
+  """
+  HEADERS = 0
+  METHOD_TYPE = 1
+  METHOD_NAME = 2
+
+
+@enum.unique
+class ServerRequestAttribute(enum.Enum):
+  """Optional tracing tags available on the server-side.
+
+  Attributes:
+    HEADERS: The initial :term:`metadata`.
+    METHOD_TYPE: Type of the method invoked.
+    METHOD_NAME: Name of the method invoked.
+  """
+  HEADERS = 0
+  METHOD_TYPE = 1
+  METHOD_NAME = 2
+
+
 def open_tracing_client_interceptor(tracer,
                                     active_span_source=None,
-                                    log_payloads=False):
+                                    log_payloads=False,
+                                    traced_attributes=None):
   """Creates a client-side interceptor that can be use with gRPC to add
          OpenTracing information.
 
@@ -33,11 +63,17 @@ def open_tracing_client_interceptor(tracer,
       A client-side interceptor object.
     """
   from grpc_opentracing import _client
+  if traced_attributes is None:
+    traced_attributes = set()
+  else:
+    traced_attributes = set(traced_attributes)
   return _client.OpenTracingClientInterceptor(tracer, active_span_source,
-                                              log_payloads)
+                                              log_payloads, traced_attributes)
 
 
-def open_tracing_server_interceptor(tracer, log_payloads=False):
+def open_tracing_server_interceptor(tracer,
+                                    log_payloads=False,
+                                    traced_attributes=None):
   """Creates a server-side interceptor that can be use with gRPC to add
          OpenTracing information.
 
@@ -49,10 +85,16 @@ def open_tracing_server_interceptor(tracer, log_payloads=False):
       A server-side interceptor object.
     """
   from grpc_opentracing import _server
-  return _server.OpenTracingServerInterceptor(tracer, log_payloads)
+  if traced_attributes is None:
+    traced_attributes = set()
+  else:
+    traced_attributes = set(traced_attributes)
+  return _server.OpenTracingServerInterceptor(tracer, log_payloads,
+                                              traced_attributes)
 
 
 ###################################  __all__  #################################
 
-__all__ = ('ActiveSpanSource', 'open_tracing_client_interceptor',
+__all__ = ('ActiveSpanSource', 'ClientRequestAttribute',
+           'ServerRequestAttribute', 'open_tracing_client_interceptor',
            'open_tracing_server_interceptor',)

--- a/python/grpc_opentracing/__init__.py
+++ b/python/grpc_opentracing/__init__.py
@@ -20,7 +20,7 @@ class ActiveSpanSource(six.with_metaclass(abc.ABCMeta)):
 
 @enum.unique
 class ClientRequestAttribute(enum.Enum):
-  """Optional tracing tags available on the client-side.
+  """Optional tracing tags available on the invocation-side.
 
   Attributes:
     HEADERS: The initial :term:`metadata`.
@@ -36,7 +36,7 @@ class ClientRequestAttribute(enum.Enum):
 
 @enum.unique
 class ServerRequestAttribute(enum.Enum):
-  """Optional tracing tags available on the server-side.
+  """Optional tracing tags available on the service-side.
 
   Attributes:
     HEADERS: The initial :term:`metadata`.
@@ -54,8 +54,8 @@ def open_tracing_client_interceptor(tracer,
                                     active_span_source=None,
                                     log_payloads=False,
                                     traced_attributes=None):
-  """Creates a client-side interceptor that can be use with gRPC to add
-         OpenTracing information.
+  """Creates an invocation-side interceptor that can be use with gRPC to add
+    OpenTracing information.
 
   Args:
     tracer: An object implmenting the opentracing.Tracer interface.
@@ -64,7 +64,7 @@ def open_tracing_client_interceptor(tracer,
     log_payloads: Indicates whether requests should be logged.
 
   Returns:
-    A client-side interceptor object.
+    An invocation-side interceptor object.
   """
   from grpc_opentracing import _client
   if traced_attributes is None:
@@ -78,15 +78,15 @@ def open_tracing_client_interceptor(tracer,
 def open_tracing_server_interceptor(tracer,
                                     log_payloads=False,
                                     traced_attributes=None):
-  """Creates a server-side interceptor that can be use with gRPC to add
-         OpenTracing information.
+  """Creates a service-side interceptor that can be use with gRPC to add
+    OpenTracing information.
 
   Args:
     tracer: An object implmenting the opentracing.Tracer interface.
     log_payloads: Indicates whether requests should be logged.
 
   Returns:
-    A server-side interceptor object.
+    A service-side interceptor object.
   """
   from grpc_opentracing import _server
   if traced_attributes is None:

--- a/python/grpc_opentracing/_client.py
+++ b/python/grpc_opentracing/_client.py
@@ -15,222 +15,222 @@ import opentracing
 
 class _OpenTracingRendezvous(grpc.Future, grpc.Call):
 
-  def __init__(self, rendezvous, method, tracer, log_payloads):
-    self._rendezvous = rendezvous
-    self._method = method
-    self._tracer = tracer
-    self._log_payloads = log_payloads
+    def __init__(self, rendezvous, method, tracer, log_payloads):
+        self._rendezvous = rendezvous
+        self._method = method
+        self._tracer = tracer
+        self._log_payloads = log_payloads
 
-  def _start_span(self):
-    span_context = None
-    error = None
+    def _start_span(self):
+        span_context = None
+        error = None
 
-    # The `trailing_metadata` method
-    #   http://www.grpc.io/grpc/python/grpc.html#grpc.Call.trailing_metadata
-    # can block. Since we want the span duration to reflect how long the
-    # invocation-side has spent waiting for a response, we thus record the
-    # time before calling `trailing_metadata` and use that as the starting time
-    # for the span
-    start_time = time.time()
-    metadata = self._rendezvous.trailing_metadata()
-    try:
-      if metadata:
-        span_context = self._tracer.extract(opentracing.Format.HTTP_HEADERS,
-                                            dict(metadata))
-    except (opentracing.UnsupportedFormatException,
-            opentracing.InvalidCarrierException,
-            opentracing.SpanContextCorruptedException) as e:
-      logging.exception('tracer.extract() failed')
-      error = e
-    tags = {'component': 'grpc', 'span.kind': 'client'}
-    references = None
-    if span_context is not None:
-      references = [opentracing.follows_from(span_context)]
-    span = self._tracer.start_span(
-        operation_name=self._method,
-        references=references,
-        tags=tags,
-        start_time=start_time)
-    if error is not None:
-      span.log_kv({'event': 'error', 'error.object': error})
-    return span
+        # The `trailing_metadata` method
+        #   http://www.grpc.io/grpc/python/grpc.html#grpc.Call.trailing_metadata
+        # can block. Since we want the span duration to reflect how long the
+        # invocation-side has spent waiting for a response, we thus record the
+        # time before calling `trailing_metadata` and use that as the starting time
+        # for the span
+        start_time = time.time()
+        metadata = self._rendezvous.trailing_metadata()
+        try:
+            if metadata:
+                span_context = self._tracer.extract(
+                    opentracing.Format.HTTP_HEADERS, dict(metadata))
+        except (opentracing.UnsupportedFormatException,
+                opentracing.InvalidCarrierException,
+                opentracing.SpanContextCorruptedException) as e:
+            logging.exception('tracer.extract() failed')
+            error = e
+        tags = {'component': 'grpc', 'span.kind': 'client'}
+        references = None
+        if span_context is not None:
+            references = [opentracing.follows_from(span_context)]
+        span = self._tracer.start_span(
+            operation_name=self._method,
+            references=references,
+            tags=tags,
+            start_time=start_time)
+        if error is not None:
+            span.log_kv({'event': 'error', 'error.object': error})
+        return span
 
-  def cancel(self, *args, **kwargs):
-    return self._rendezvous.cancel(*args, **kwargs)
+    def cancel(self, *args, **kwargs):
+        return self._rendezvous.cancel(*args, **kwargs)
 
-  def cancelled(self, *args, **kwargs):
-    return self._rendezvous.cancelled(*args, **kwargs)
+    def cancelled(self, *args, **kwargs):
+        return self._rendezvous.cancelled(*args, **kwargs)
 
-  def running(self, *args, **kwargs):
-    return self._rendezvous.running(*args, **kwargs)
+    def running(self, *args, **kwargs):
+        return self._rendezvous.running(*args, **kwargs)
 
-  def done(self, *args, **kwargs):
-    return self._rendezvous.done(*args, **kwargs)
+    def done(self, *args, **kwargs):
+        return self._rendezvous.done(*args, **kwargs)
 
-  def result(self, timeout=None):
-    with self._start_span() as span:
-      try:
-        response = self._rendezvous.result(timeout)
-        if self._log_payloads:
-          span.log_kv({'response': response})
-        return response
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
+    def result(self, timeout=None):
+        with self._start_span() as span:
+            try:
+                response = self._rendezvous.result(timeout)
+                if self._log_payloads:
+                    span.log_kv({'response': response})
+                return response
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
 
-  def exception(self, *args, **kwargs):
-    return self._rendezvous.exception(*args, **kwargs)
+    def exception(self, *args, **kwargs):
+        return self._rendezvous.exception(*args, **kwargs)
 
-  def traceback(self, *args, **kwargs):
-    return self._rendezvous.traceback(*args, **kwargs)
+    def traceback(self, *args, **kwargs):
+        return self._rendezvous.traceback(*args, **kwargs)
 
-  def add_callback(self, *args, **kwargs):
-    return self._rendezvous.add_callback(*args, **kwargs)
+    def add_callback(self, *args, **kwargs):
+        return self._rendezvous.add_callback(*args, **kwargs)
 
-  def add_done_callback(self, *args, **kwargs):
-    return self._rendezvous.add_done_callback(*args, **kwargs)
+    def add_done_callback(self, *args, **kwargs):
+        return self._rendezvous.add_done_callback(*args, **kwargs)
 
-  def is_active(self, *args, **kwargs):
-    return self._rendezvous.is_active(*args, **kwargs)
+    def is_active(self, *args, **kwargs):
+        return self._rendezvous.is_active(*args, **kwargs)
 
-  def time_remaining(self, *args, **kwargs):
-    return self._rendezvous.time_remaining(*args, **kwargs)
+    def time_remaining(self, *args, **kwargs):
+        return self._rendezvous.time_remaining(*args, **kwargs)
 
-  def initial_metadata(self, *args, **kwargs):
-    return self._rendezvous.initial_metadata(*args, **kwargs)
+    def initial_metadata(self, *args, **kwargs):
+        return self._rendezvous.initial_metadata(*args, **kwargs)
 
-  def trailing_metadata(self, *args, **kwargs):
-    return self._rendezvous.trailing_metadata(*args, **kwargs)
+    def trailing_metadata(self, *args, **kwargs):
+        return self._rendezvous.trailing_metadata(*args, **kwargs)
 
-  def code(self, *args, **kwargs):
-    return self._rendezvous.code(*args, **kwargs)
+    def code(self, *args, **kwargs):
+        return self._rendezvous.code(*args, **kwargs)
 
-  def details(self, *args, **kwargs):
-    return self._rendezvous.details(*args, **kwargs)
+    def details(self, *args, **kwargs):
+        return self._rendezvous.details(*args, **kwargs)
 
 
 def _inject_span_context(tracer, span, metadata):
-  headers = {}
-  try:
-    tracer.inject(span.context, opentracing.Format.HTTP_HEADERS, headers)
-  except (opentracing.UnsupportedFormatException,
-          opentracing.InvalidCarrierException,
-          opentracing.SpanContextCorruptedException) as e:
-    logging.exception('tracer.inject() failed')
-    span.log_kv({'event': 'error', 'error.object': e})
-    return metadata
-  metadata = () if metadata is None else tuple(metadata)
-  return metadata + tuple(iteritems(headers))
+    headers = {}
+    try:
+        tracer.inject(span.context, opentracing.Format.HTTP_HEADERS, headers)
+    except (opentracing.UnsupportedFormatException,
+            opentracing.InvalidCarrierException,
+            opentracing.SpanContextCorruptedException) as e:
+        logging.exception('tracer.inject() failed')
+        span.log_kv({'event': 'error', 'error.object': e})
+        return metadata
+    metadata = () if metadata is None else tuple(metadata)
+    return metadata + tuple(iteritems(headers))
 
 
 def _wrap_result(tracer, span, method, log_payloads, result):
-  # If the RPC is called asynchronously, wrap the future so that an
-  # additional span can be created once it's realized.
-  if isinstance(result, grpc.Future):
-    return _OpenTracingRendezvous(result, method, tracer, log_payloads)
-  elif log_payloads:
-    response = result
-    # Handle the case when the RPC is initiated via the with_call
-    # method and the result is a tuple with the first element as the
-    # response.
-    # http://www.grpc.io/grpc/python/grpc.html#grpc.UnaryUnaryMultiCallable.with_call
-    if isinstance(result, tuple):
-      response = result[0]
-    span.log_kv({'response': response})
-  return result
+    # If the RPC is called asynchronously, wrap the future so that an
+    # additional span can be created once it's realized.
+    if isinstance(result, grpc.Future):
+        return _OpenTracingRendezvous(result, method, tracer, log_payloads)
+    elif log_payloads:
+        response = result
+        # Handle the case when the RPC is initiated via the with_call
+        # method and the result is a tuple with the first element as the
+        # response.
+        # http://www.grpc.io/grpc/python/grpc.html#grpc.UnaryUnaryMultiCallable.with_call
+        if isinstance(result, tuple):
+            response = result[0]
+        span.log_kv({'response': response})
+    return result
 
 
 class OpenTracingClientInterceptor(grpcext.UnaryClientInterceptor,
                                    grpcext.StreamClientInterceptor):
 
-  def __init__(self, tracer, active_span_source, log_payloads,
-               traced_attributes):
-    self._tracer = tracer
-    self._active_span_source = active_span_source
-    self._log_payloads = log_payloads
-    self._traced_attributes = traced_attributes
+    def __init__(self, tracer, active_span_source, log_payloads,
+                 traced_attributes):
+        self._tracer = tracer
+        self._active_span_source = active_span_source
+        self._log_payloads = log_payloads
+        self._traced_attributes = traced_attributes
 
-  def _start_span(self, method, metadata, is_client_stream, is_server_stream,
-                  timeout):
-    active_span_context = None
-    if self._active_span_source is not None:
-      active_span = self._active_span_source.get_active_span()
-      if active_span is not None:
-        active_span_context = active_span.context
-    tags = {'component': 'grpc', 'span.kind': 'client'}
-    for traced_attribute in self._traced_attributes:
-      if traced_attribute == ClientRequestAttribute.HEADERS:
-        tags['grpc.headers'] = str(metadata)
-      elif traced_attribute == ClientRequestAttribute.METHOD_TYPE:
-        tags['grpc.method_type'] = get_method_type(is_client_stream,
-                                                   is_server_stream)
-      elif traced_attribute == ClientRequestAttribute.METHOD_NAME:
-        tags['grpc.method_name'] = method
-      elif traced_attribute == ClientRequestAttribute.DEADLINE:
-        tags['grpc.deadline_millis'] = get_deadline_millis(timeout)
-      else:
-        logging.warning('OpenTracing Attribute \"%s\" is not supported',
-                        str(traced_attribute))
-    return self._tracer.start_span(
-        operation_name=method, child_of=active_span_context, tags=tags)
+    def _start_span(self, method, metadata, is_client_stream, is_server_stream,
+                    timeout):
+        active_span_context = None
+        if self._active_span_source is not None:
+            active_span = self._active_span_source.get_active_span()
+            if active_span is not None:
+                active_span_context = active_span.context
+        tags = {'component': 'grpc', 'span.kind': 'client'}
+        for traced_attribute in self._traced_attributes:
+            if traced_attribute == ClientRequestAttribute.HEADERS:
+                tags['grpc.headers'] = str(metadata)
+            elif traced_attribute == ClientRequestAttribute.METHOD_TYPE:
+                tags['grpc.method_type'] = get_method_type(is_client_stream,
+                                                           is_server_stream)
+            elif traced_attribute == ClientRequestAttribute.METHOD_NAME:
+                tags['grpc.method_name'] = method
+            elif traced_attribute == ClientRequestAttribute.DEADLINE:
+                tags['grpc.deadline_millis'] = get_deadline_millis(timeout)
+            else:
+                logging.warning('OpenTracing Attribute \"%s\" is not supported',
+                                str(traced_attribute))
+        return self._tracer.start_span(
+            operation_name=method, child_of=active_span_context, tags=tags)
 
-  def intercept_unary(self, request, metadata, client_info, invoker):
-    with self._start_span(client_info.full_method, metadata, False, False,
-                          client_info.timeout) as span:
-      metadata = _inject_span_context(self._tracer, span, metadata)
-      if self._log_payloads:
-        span.log_kv({'request': request})
-      try:
-        result = invoker(request, metadata)
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
-      return _wrap_result(self._tracer, span, client_info.full_method,
-                          self._log_payloads, result)
+    def intercept_unary(self, request, metadata, client_info, invoker):
+        with self._start_span(client_info.full_method, metadata, False, False,
+                              client_info.timeout) as span:
+            metadata = _inject_span_context(self._tracer, span, metadata)
+            if self._log_payloads:
+                span.log_kv({'request': request})
+            try:
+                result = invoker(request, metadata)
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
+            return _wrap_result(self._tracer, span, client_info.full_method,
+                                self._log_payloads, result)
 
-  # For RPCs that stream responses, the result can be a generator. To record
-  # the span across the generated responses and detect any errors, we wrap the
-  # result in a new generator that yields the response values.
-  def _intercept_server_stream(self, request_or_iterator, metadata, client_info,
-                               invoker):
-    with self._start_span(client_info.full_method, metadata,
-                          client_info.is_client_stream, True,
-                          client_info.timeout) as span:
-      metadata = _inject_span_context(self._tracer, span, metadata)
-      if self._log_payloads:
-        request_or_iterator = log_or_wrap_request_or_iterator(
-            span, client_info.is_client_stream, request_or_iterator)
-      try:
-        result = invoker(request_or_iterator, metadata)
-        for response in result:
-          if self._log_payloads:
-            span.log_kv({'response': response})
-          yield response
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
+    # For RPCs that stream responses, the result can be a generator. To record
+    # the span across the generated responses and detect any errors, we wrap the
+    # result in a new generator that yields the response values.
+    def _intercept_server_stream(self, request_or_iterator, metadata,
+                                 client_info, invoker):
+        with self._start_span(client_info.full_method, metadata,
+                              client_info.is_client_stream, True,
+                              client_info.timeout) as span:
+            metadata = _inject_span_context(self._tracer, span, metadata)
+            if self._log_payloads:
+                request_or_iterator = log_or_wrap_request_or_iterator(
+                    span, client_info.is_client_stream, request_or_iterator)
+            try:
+                result = invoker(request_or_iterator, metadata)
+                for response in result:
+                    if self._log_payloads:
+                        span.log_kv({'response': response})
+                    yield response
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
 
-  def intercept_stream(self, request_or_iterator, metadata, client_info,
-                       invoker):
-    if client_info.is_server_stream:
-      return self._intercept_server_stream(request_or_iterator, metadata,
-                                           client_info, invoker)
-    with self._start_span(client_info.full_method, metadata,
-                          client_info.is_client_stream, False,
-                          client_info.timeout) as span:
-      metadata = _inject_span_context(self._tracer, span, metadata)
-      try:
-        result = invoker(request_or_iterator, metadata)
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
-      return _wrap_result(self._tracer, span, client_info.full_method, False,
-                          result)
+    def intercept_stream(self, request_or_iterator, metadata, client_info,
+                         invoker):
+        if client_info.is_server_stream:
+            return self._intercept_server_stream(request_or_iterator, metadata,
+                                                 client_info, invoker)
+        with self._start_span(client_info.full_method, metadata,
+                              client_info.is_client_stream, False,
+                              client_info.timeout) as span:
+            metadata = _inject_span_context(self._tracer, span, metadata)
+            try:
+                result = invoker(request_or_iterator, metadata)
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
+            return _wrap_result(self._tracer, span, client_info.full_method,
+                                False, result)

--- a/python/grpc_opentracing/_client.py
+++ b/python/grpc_opentracing/_client.py
@@ -13,102 +13,25 @@ from grpc_opentracing._utilities import get_method_type, get_deadline_millis,\
 import opentracing
 
 
-class _OpenTracingRendezvous(grpc.Future, grpc.Call):
+class _GuardedSpan(object):
 
-    def __init__(self, rendezvous, method, tracer, log_payloads):
-        self._rendezvous = rendezvous
-        self._method = method
-        self._tracer = tracer
-        self._log_payloads = log_payloads
+    def __init__(self, span):
+        self.span = span
+        self._engaged = True
 
-    def _start_span(self):
-        span_context = None
-        error = None
+    def __enter__(self):
+        self.span.__enter__()
+        return self
 
-        # The `trailing_metadata` method
-        #   http://www.grpc.io/grpc/python/grpc.html#grpc.Call.trailing_metadata
-        # can block. Since we want the span duration to reflect how long the
-        # invocation-side has spent waiting for a response, we thus record the
-        # time before calling `trailing_metadata` and use that as the starting time
-        # for the span
-        start_time = time.time()
-        metadata = self._rendezvous.trailing_metadata()
-        try:
-            if metadata:
-                span_context = self._tracer.extract(
-                    opentracing.Format.HTTP_HEADERS, dict(metadata))
-        except (opentracing.UnsupportedFormatException,
-                opentracing.InvalidCarrierException,
-                opentracing.SpanContextCorruptedException) as e:
-            logging.exception('tracer.extract() failed')
-            error = e
-        tags = {'component': 'grpc', 'span.kind': 'client'}
-        references = None
-        if span_context is not None:
-            references = [opentracing.follows_from(span_context)]
-        span = self._tracer.start_span(
-            operation_name=self._method,
-            references=references,
-            tags=tags,
-            start_time=start_time)
-        if error is not None:
-            span.log_kv({'event': 'error', 'error.object': error})
-        return span
+    def __exit__(self, *args, **kwargs):
+        if self._engaged:
+            return self.span.__exit__(*args, **kwargs)
+        else:
+            return False
 
-    def cancel(self, *args, **kwargs):
-        return self._rendezvous.cancel(*args, **kwargs)
-
-    def cancelled(self, *args, **kwargs):
-        return self._rendezvous.cancelled(*args, **kwargs)
-
-    def running(self, *args, **kwargs):
-        return self._rendezvous.running(*args, **kwargs)
-
-    def done(self, *args, **kwargs):
-        return self._rendezvous.done(*args, **kwargs)
-
-    def result(self, timeout=None):
-        with self._start_span() as span:
-            try:
-                response = self._rendezvous.result(timeout)
-                if self._log_payloads:
-                    span.log_kv({'response': response})
-                return response
-            except:
-                e = sys.exc_info()[0]
-                span.set_tag('error', True)
-                span.log_kv({'event': 'error', 'error.object': e})
-                raise
-
-    def exception(self, *args, **kwargs):
-        return self._rendezvous.exception(*args, **kwargs)
-
-    def traceback(self, *args, **kwargs):
-        return self._rendezvous.traceback(*args, **kwargs)
-
-    def add_callback(self, *args, **kwargs):
-        return self._rendezvous.add_callback(*args, **kwargs)
-
-    def add_done_callback(self, *args, **kwargs):
-        return self._rendezvous.add_done_callback(*args, **kwargs)
-
-    def is_active(self, *args, **kwargs):
-        return self._rendezvous.is_active(*args, **kwargs)
-
-    def time_remaining(self, *args, **kwargs):
-        return self._rendezvous.time_remaining(*args, **kwargs)
-
-    def initial_metadata(self, *args, **kwargs):
-        return self._rendezvous.initial_metadata(*args, **kwargs)
-
-    def trailing_metadata(self, *args, **kwargs):
-        return self._rendezvous.trailing_metadata(*args, **kwargs)
-
-    def code(self, *args, **kwargs):
-        return self._rendezvous.code(*args, **kwargs)
-
-    def details(self, *args, **kwargs):
-        return self._rendezvous.details(*args, **kwargs)
+    def release(self):
+        self._engaged = False
+        return self.span
 
 
 def _inject_span_context(tracer, span, metadata):
@@ -125,11 +48,32 @@ def _inject_span_context(tracer, span, metadata):
     return metadata + tuple(iteritems(headers))
 
 
-def _wrap_result(tracer, span, method, log_payloads, result):
-    # If the RPC is called asynchronously, wrap the future so that an
-    # additional span can be created once it's realized.
+def _make_future_done_callback(span, log_payloads):
+
+    def callback(response_future):
+        with span:
+            code = response_future.code()
+            if code != grpc.StatusCode.OK:
+                span.set_tag('error', True)
+                error_log = {'event': 'error', 'error.kind': str(code)}
+                details = response_future.details()
+                if details is not None:
+                    error_log['message'] = details
+                span.log_kv(error_log)
+            elif log_payloads:
+                response = response_future.result()
+                span.log_kv({'response': response})
+
+    return callback
+
+
+def _trace_result(guarded_span, log_payloads, result):
+    # If the RPC is called asynchronously, release the guard and add a callback
+    # so that the span can be finished once the future is done.
     if isinstance(result, grpc.Future):
-        return _OpenTracingRendezvous(result, method, tracer, log_payloads)
+        result.add_done_callback(
+            _make_future_done_callback(guarded_span.release(), log_payloads))
+        return result
     elif log_payloads:
         response = result
         # Handle the case when the RPC is initiated via the with_call
@@ -138,7 +82,7 @@ def _wrap_result(tracer, span, method, log_payloads, result):
         # http://www.grpc.io/grpc/python/grpc.html#grpc.UnaryUnaryMultiCallable.with_call
         if isinstance(result, tuple):
             response = result[0]
-        span.log_kv({'response': response})
+        guarded_span.span.log_kv({'response': response})
     return result
 
 
@@ -176,21 +120,25 @@ class OpenTracingClientInterceptor(grpcext.UnaryClientInterceptor,
         return self._tracer.start_span(
             operation_name=method, child_of=active_span_context, tags=tags)
 
+    def _start_guarded_span(self, *args, **kwargs):
+        return _GuardedSpan(self._start_span(*args, **kwargs))
+
     def intercept_unary(self, request, metadata, client_info, invoker):
-        with self._start_span(client_info.full_method, metadata, False, False,
-                              client_info.timeout) as span:
-            metadata = _inject_span_context(self._tracer, span, metadata)
+        with self._start_guarded_span(client_info.full_method, metadata, False,
+                                      False,
+                                      client_info.timeout) as guarded_span:
+            metadata = _inject_span_context(self._tracer, guarded_span.span,
+                                            metadata)
             if self._log_payloads:
-                span.log_kv({'request': request})
+                guarded_span.span.log_kv({'request': request})
             try:
                 result = invoker(request, metadata)
             except:
                 e = sys.exc_info()[0]
-                span.set_tag('error', True)
-                span.log_kv({'event': 'error', 'error.object': e})
+                guarded_span.span.set_tag('error', True)
+                guarded_span.span.log_kv({'event': 'error', 'error.object': e})
                 raise
-            return _wrap_result(self._tracer, span, client_info.full_method,
-                                self._log_payloads, result)
+            return _trace_result(guarded_span, self._log_payloads, result)
 
     # For RPCs that stream responses, the result can be a generator. To record
     # the span across the generated responses and detect any errors, we wrap the
@@ -221,16 +169,20 @@ class OpenTracingClientInterceptor(grpcext.UnaryClientInterceptor,
         if client_info.is_server_stream:
             return self._intercept_server_stream(request_or_iterator, metadata,
                                                  client_info, invoker)
-        with self._start_span(client_info.full_method, metadata,
-                              client_info.is_client_stream, False,
-                              client_info.timeout) as span:
-            metadata = _inject_span_context(self._tracer, span, metadata)
+        with self._start_guarded_span(client_info.full_method, metadata,
+                                      client_info.is_client_stream, False,
+                                      client_info.timeout) as guarded_span:
+            metadata = _inject_span_context(self._tracer, guarded_span.span,
+                                            metadata)
+            if self._log_payloads:
+                request_or_iterator = log_or_wrap_request_or_iterator(
+                    guarded_span.span, client_info.is_client_stream,
+                    request_or_iterator)
             try:
                 result = invoker(request_or_iterator, metadata)
             except:
                 e = sys.exc_info()[0]
-                span.set_tag('error', True)
-                span.log_kv({'event': 'error', 'error.object': e})
+                guarded_span.span.set_tag('error', True)
+                guarded_span.span.log_kv({'event': 'error', 'error.object': e})
                 raise
-            return _wrap_result(self._tracer, span, client_info.full_method,
-                                False, result)
+            return _trace_result(guarded_span, self._log_payloads, result)

--- a/python/grpc_opentracing/_client.py
+++ b/python/grpc_opentracing/_client.py
@@ -208,15 +208,15 @@ class OpenTracingClientInterceptor(grpcext.UnaryClientInterceptor,
       metadata = _inject_span_context(self._tracer, span, metadata)
       try:
         result = invoker(metadata)
-        # If the RPC is called asynchronously, wrap the future so that an
-        # additional span is created once it's realized.
-        if isinstance(result, grpc.Future):
-          return _OpenTracingRendezvous(result, client_info.full_method,
-                                        self._tracer, False)
-        else:
-          return result
       except:
         e = sys.exc_info()[0]
         span.set_tag('error', True)
         span.log_kv({'event': 'error', 'error.object': e})
         raise
+      # If the RPC is called asynchronously, wrap the future so that an
+      # additional span can be created once it's realized.
+      if isinstance(result, grpc.Future):
+        return _OpenTracingRendezvous(result, client_info.full_method,
+                                      self._tracer, False)
+      else:
+        return result

--- a/python/grpc_opentracing/_client.py
+++ b/python/grpc_opentracing/_client.py
@@ -1,4 +1,4 @@
-"""Implementation of the client-side open-tracing interceptor."""
+"""Implementation of the invocation-side open-tracing interceptor."""
 
 import sys
 import logging

--- a/python/grpc_opentracing/_server.py
+++ b/python/grpc_opentracing/_server.py
@@ -15,218 +15,220 @@ import opentracing
 
 class _OpenTracingServicerContext(grpc.ServicerContext, ActiveSpanSource):
 
-  def __init__(self, servicer_context, active_span, trailing_metadata=None):
-    self._servicer_context = servicer_context
-    self._active_span = active_span
-    self._trailing_metadata = trailing_metadata
-    self.code = grpc.StatusCode.OK
-    self.details = None
+    def __init__(self, servicer_context, active_span, trailing_metadata=None):
+        self._servicer_context = servicer_context
+        self._active_span = active_span
+        self._trailing_metadata = trailing_metadata
+        self.code = grpc.StatusCode.OK
+        self.details = None
 
-  def is_active(self, *args, **kwargs):
-    return self._servicer_context.is_active(*args, **kwargs)
+    def is_active(self, *args, **kwargs):
+        return self._servicer_context.is_active(*args, **kwargs)
 
-  def time_remaining(self, *args, **kwargs):
-    return self._servicer_context.time_remaining(*args, **kwargs)
+    def time_remaining(self, *args, **kwargs):
+        return self._servicer_context.time_remaining(*args, **kwargs)
 
-  def cancel(self, *args, **kwargs):
-    return self._servicer_context.cancel(*args, **kwargs)
+    def cancel(self, *args, **kwargs):
+        return self._servicer_context.cancel(*args, **kwargs)
 
-  def add_callback(self, *args, **kwargs):
-    return self._servicer_context.add_callback(*args, **kwargs)
+    def add_callback(self, *args, **kwargs):
+        return self._servicer_context.add_callback(*args, **kwargs)
 
-  def invocation_metadata(self, *args, **kwargs):
-    return self._servicer_context.invocation_metadata(*args, **kwargs)
+    def invocation_metadata(self, *args, **kwargs):
+        return self._servicer_context.invocation_metadata(*args, **kwargs)
 
-  def peer(self, *args, **kwargs):
-    return self._servicer_context.peer(*args, **kwargs)
+    def peer(self, *args, **kwargs):
+        return self._servicer_context.peer(*args, **kwargs)
 
-  def send_initial_metadata(self, *args, **kwargs):
-    return self._servicer_context.send_initial_metadata(*args, **kwargs)
+    def send_initial_metadata(self, *args, **kwargs):
+        return self._servicer_context.send_initial_metadata(*args, **kwargs)
 
-  def set_trailing_metadata(self, trailing_metadata):
-    # In some situations, the servicer-side may send its span context back as
-    # trailing metadata. If other code on the servicer-side is also setting
-    # trailing metadata, we need to intercept and append the initial trailing
-    # metadata so that it doesn't get overwritten.
-    if self._trailing_metadata is None:
-      return self._servicer_context.set_trailing_metadata(trailing_metadata)
-    trailing_metadata = tuple(
-        trailing_metadata) if trailing_metadata is not None else ()
-    trailing_metadata = self._trailing_metadata + trailing_metadata
-    return self._servicer_context.set_trailing_metadata(trailing_metadata)
+    def set_trailing_metadata(self, trailing_metadata):
+        # In some situations, the servicer-side may send its span context back as
+        # trailing metadata. If other code on the servicer-side is also setting
+        # trailing metadata, we need to intercept and append the initial trailing
+        # metadata so that it doesn't get overwritten.
+        if self._trailing_metadata is None:
+            return self._servicer_context.set_trailing_metadata(
+                trailing_metadata)
+        trailing_metadata = tuple(
+            trailing_metadata) if trailing_metadata is not None else ()
+        trailing_metadata = self._trailing_metadata + trailing_metadata
+        return self._servicer_context.set_trailing_metadata(trailing_metadata)
 
-  def set_code(self, code):
-    self.code = code
-    return self._servicer_context.set_code(code)
+    def set_code(self, code):
+        self.code = code
+        return self._servicer_context.set_code(code)
 
-  def set_details(self, details):
-    self.details = details
-    return self._servicer_context.set_details(details)
+    def set_details(self, details):
+        self.details = details
+        return self._servicer_context.set_details(details)
 
-  def get_active_span(self):
-    return self._active_span
+    def get_active_span(self):
+        return self._active_span
 
 
 def _add_peer_tags(peer_str, tags):
-  ipv4_re = r"ipv4:(?P<address>.+):(?P<port>\d+)"
-  match = re.match(ipv4_re, peer_str)
-  if match:
-    tags['peer.ipv4'] = match.group('address')
-    tags['peer.port'] = match.group('port')
-    return
-  ipv6_re = r"ipv6:\[(?P<address>.+)\]:(?P<port>\d+)"
-  match = re.match(ipv6_re, peer_str)
-  if match:
-    tags['peer.ipv6'] = match.group('address')
-    tags['peer.port'] = match.group('port')
-    return
-  logging.warning('Unrecognized peer: \"%s\"', peer_str)
+    ipv4_re = r"ipv4:(?P<address>.+):(?P<port>\d+)"
+    match = re.match(ipv4_re, peer_str)
+    if match:
+        tags['peer.ipv4'] = match.group('address')
+        tags['peer.port'] = match.group('port')
+        return
+    ipv6_re = r"ipv6:\[(?P<address>.+)\]:(?P<port>\d+)"
+    match = re.match(ipv6_re, peer_str)
+    if match:
+        tags['peer.ipv6'] = match.group('address')
+        tags['peer.port'] = match.group('port')
+        return
+    logging.warning('Unrecognized peer: \"%s\"', peer_str)
 
 
 def _inject_span_context(tracer, span, servicer_context):
-  headers = {}
-  try:
-    tracer.inject(span.context, opentracing.Format.HTTP_HEADERS, headers)
-  except (opentracing.UnsupportedFormatException,
-          opentracing.InvalidCarrierException,
-          opentracing.SpanContextCorruptedException) as e:
-    logging.exception('tracer.inject() failed')
-    span.log_kv({'event': 'error', 'error.object': e})
-    return None
-  metadata = tuple(iteritems(headers))
-  servicer_context.set_trailing_metadata(metadata)
-  return metadata
+    headers = {}
+    try:
+        tracer.inject(span.context, opentracing.Format.HTTP_HEADERS, headers)
+    except (opentracing.UnsupportedFormatException,
+            opentracing.InvalidCarrierException,
+            opentracing.SpanContextCorruptedException) as e:
+        logging.exception('tracer.inject() failed')
+        span.log_kv({'event': 'error', 'error.object': e})
+        return None
+    metadata = tuple(iteritems(headers))
+    servicer_context.set_trailing_metadata(metadata)
+    return metadata
 
 
 # On the service-side, errors can be signaled either by exceptions or by calling
 # `set_code` on the `servicer_context`. This function checks for the latter and
 # updates the span accordingly.
 def _check_error_code(span, servicer_context):
-  if servicer_context.code != grpc.StatusCode.OK:
-    span.set_tag('error', True)
-    error_log = {'event': 'error', 'error.kind': str(servicer_context.code)}
-    if servicer_context.details is not None:
-      error_log['message'] = servicer_context.details
-    span.log_kv(error_log)
+    if servicer_context.code != grpc.StatusCode.OK:
+        span.set_tag('error', True)
+        error_log = {'event': 'error', 'error.kind': str(servicer_context.code)}
+        if servicer_context.details is not None:
+            error_log['message'] = servicer_context.details
+        span.log_kv(error_log)
 
 
 class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
                                    grpcext.StreamServerInterceptor):
 
-  def __init__(self, tracer, log_payloads, traced_attributes):
-    self._tracer = tracer
-    self._log_payloads = log_payloads
-    self._traced_attributes = traced_attributes
+    def __init__(self, tracer, log_payloads, traced_attributes):
+        self._tracer = tracer
+        self._log_payloads = log_payloads
+        self._traced_attributes = traced_attributes
 
-  def _start_span(self, servicer_context, method, is_client_stream,
-                  is_server_stream):
-    span_context = None
-    error = None
-    metadata = servicer_context.invocation_metadata()
-    try:
-      if metadata:
-        span_context = self._tracer.extract(opentracing.Format.HTTP_HEADERS,
-                                            dict(metadata))
-    except (opentracing.UnsupportedFormatException,
-            opentracing.InvalidCarrierException,
-            opentracing.SpanContextCorruptedException) as e:
-      logging.exception('tracer.extract() failed')
-      error = e
-    tags = {'component': 'grpc', 'span.kind': 'server'}
-    _add_peer_tags(servicer_context.peer(), tags)
-    for traced_attribute in self._traced_attributes:
-      if traced_attribute == ServerRequestAttribute.HEADERS:
-        tags['grpc.headers'] = str(metadata)
-      elif traced_attribute == ServerRequestAttribute.METHOD_TYPE:
-        tags['grpc.method_type'] = get_method_type(is_client_stream,
-                                                   is_server_stream)
-      elif traced_attribute == ServerRequestAttribute.METHOD_NAME:
-        tags['grpc.method_name'] = method
-      elif traced_attribute == ServerRequestAttribute.DEADLINE:
-        tags['grpc.deadline_millis'] = get_deadline_millis(
-            servicer_context.time_remaining())
-      else:
-        logging.warning('OpenTracing Attribute \"%s\" is not supported',
-                        str(traced_attribute))
-    span = self._tracer.start_span(
-        operation_name=method, child_of=span_context, tags=tags)
-    if error is not None:
-      span.log_kv({'event': 'error', 'error.object': error})
-    return span
+    def _start_span(self, servicer_context, method, is_client_stream,
+                    is_server_stream):
+        span_context = None
+        error = None
+        metadata = servicer_context.invocation_metadata()
+        try:
+            if metadata:
+                span_context = self._tracer.extract(
+                    opentracing.Format.HTTP_HEADERS, dict(metadata))
+        except (opentracing.UnsupportedFormatException,
+                opentracing.InvalidCarrierException,
+                opentracing.SpanContextCorruptedException) as e:
+            logging.exception('tracer.extract() failed')
+            error = e
+        tags = {'component': 'grpc', 'span.kind': 'server'}
+        _add_peer_tags(servicer_context.peer(), tags)
+        for traced_attribute in self._traced_attributes:
+            if traced_attribute == ServerRequestAttribute.HEADERS:
+                tags['grpc.headers'] = str(metadata)
+            elif traced_attribute == ServerRequestAttribute.METHOD_TYPE:
+                tags['grpc.method_type'] = get_method_type(is_client_stream,
+                                                           is_server_stream)
+            elif traced_attribute == ServerRequestAttribute.METHOD_NAME:
+                tags['grpc.method_name'] = method
+            elif traced_attribute == ServerRequestAttribute.DEADLINE:
+                tags['grpc.deadline_millis'] = get_deadline_millis(
+                    servicer_context.time_remaining())
+            else:
+                logging.warning('OpenTracing Attribute \"%s\" is not supported',
+                                str(traced_attribute))
+        span = self._tracer.start_span(
+            operation_name=method, child_of=span_context, tags=tags)
+        if error is not None:
+            span.log_kv({'event': 'error', 'error.object': error})
+        return span
 
-  def intercept_unary(self, request, servicer_context, server_info, handler):
-    with self._start_span(servicer_context, server_info.full_method, False,
-                          False) as span:
-      if self._log_payloads:
-        span.log_kv({'request': request})
-      # The invocation-side may have invoked this RPC asynchronously; in which
-      # case, it may want to reference the servicer-side's span context, so
-      # we send it back in the trailing_metadata
-      trailing_metadata = _inject_span_context(self._tracer, span,
-                                               servicer_context)
-      servicer_context = _OpenTracingServicerContext(servicer_context, span,
-                                                     trailing_metadata)
-      try:
-        response = handler(request, servicer_context)
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
-      if self._log_payloads:
-        span.log_kv({'response': response})
-      _check_error_code(span, servicer_context)
-      return response
+    def intercept_unary(self, request, servicer_context, server_info, handler):
+        with self._start_span(servicer_context, server_info.full_method, False,
+                              False) as span:
+            if self._log_payloads:
+                span.log_kv({'request': request})
+            # The invocation-side may have invoked this RPC asynchronously; in which
+            # case, it may want to reference the servicer-side's span context, so
+            # we send it back in the trailing_metadata
+            trailing_metadata = _inject_span_context(self._tracer, span,
+                                                     servicer_context)
+            servicer_context = _OpenTracingServicerContext(
+                servicer_context, span, trailing_metadata)
+            try:
+                response = handler(request, servicer_context)
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
+            if self._log_payloads:
+                span.log_kv({'response': response})
+            _check_error_code(span, servicer_context)
+            return response
 
-  # For RPCs that stream responses, the result can be a generator. To record
-  # the span across the generated responses and detect any errors, we wrap the
-  # result in a new generator that yields the response values.
-  def _intercept_server_stream(self, request_or_iterator, servicer_context,
-                               server_info, handler):
-    with self._start_span(servicer_context, server_info.full_method,
-                          server_info.is_client_stream, True) as span:
-      servicer_context = _OpenTracingServicerContext(servicer_context, span)
-      if self._log_payloads:
-        request_or_iterator = log_or_wrap_request_or_iterator(
-            span, server_info.is_client_stream, request_or_iterator)
-      try:
-        result = handler(request_or_iterator, servicer_context)
-        for response in result:
-          if self._log_payloads:
-            span.log_kv({'response': response})
-          yield response
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
-      _check_error_code(span, servicer_context)
+    # For RPCs that stream responses, the result can be a generator. To record
+    # the span across the generated responses and detect any errors, we wrap the
+    # result in a new generator that yields the response values.
+    def _intercept_server_stream(self, request_or_iterator, servicer_context,
+                                 server_info, handler):
+        with self._start_span(servicer_context, server_info.full_method,
+                              server_info.is_client_stream, True) as span:
+            servicer_context = _OpenTracingServicerContext(servicer_context,
+                                                           span)
+            if self._log_payloads:
+                request_or_iterator = log_or_wrap_request_or_iterator(
+                    span, server_info.is_client_stream, request_or_iterator)
+            try:
+                result = handler(request_or_iterator, servicer_context)
+                for response in result:
+                    if self._log_payloads:
+                        span.log_kv({'response': response})
+                    yield response
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
+            _check_error_code(span, servicer_context)
 
-  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
-                       handler):
-    if server_info.is_server_stream:
-      return self._intercept_server_stream(
-          request_or_iterator, servicer_context, server_info, handler)
-    with self._start_span(servicer_context, server_info.full_method,
-                          server_info.is_client_stream, False) as span:
-      # The invocation-side may have invoked this RPC asynchronously; in which
-      # case, it may want to reference the servicer-side's span context, so
-      # we send it back in the trailing_metadata
-      trailing_metadata = _inject_span_context(self._tracer, span,
-                                               servicer_context)
-      servicer_context = _OpenTracingServicerContext(servicer_context, span,
-                                                     trailing_metadata)
-      if self._log_payloads:
-        request_or_iterator = log_or_wrap_request_or_iterator(
-            span, server_info.is_client_stream, request_or_iterator)
-      try:
-        response = handler(request_or_iterator, servicer_context)
-      except:
-        e = sys.exc_info()[0]
-        span.set_tag('error', True)
-        span.log_kv({'event': 'error', 'error.object': e})
-        raise
-      if self._log_payloads:
-        span.log_kv({'response': response})
-      _check_error_code(span, servicer_context)
-      return response
+    def intercept_stream(self, request_or_iterator, servicer_context,
+                         server_info, handler):
+        if server_info.is_server_stream:
+            return self._intercept_server_stream(
+                request_or_iterator, servicer_context, server_info, handler)
+        with self._start_span(servicer_context, server_info.full_method,
+                              server_info.is_client_stream, False) as span:
+            # The invocation-side may have invoked this RPC asynchronously; in which
+            # case, it may want to reference the servicer-side's span context, so
+            # we send it back in the trailing_metadata
+            trailing_metadata = _inject_span_context(self._tracer, span,
+                                                     servicer_context)
+            servicer_context = _OpenTracingServicerContext(
+                servicer_context, span, trailing_metadata)
+            if self._log_payloads:
+                request_or_iterator = log_or_wrap_request_or_iterator(
+                    span, server_info.is_client_stream, request_or_iterator)
+            try:
+                response = handler(request_or_iterator, servicer_context)
+            except:
+                e = sys.exc_info()[0]
+                span.set_tag('error', True)
+                span.log_kv({'event': 'error', 'error.object': e})
+                raise
+            if self._log_payloads:
+                span.log_kv({'response': response})
+            _check_error_code(span, servicer_context)
+            return response

--- a/python/grpc_opentracing/_server.py
+++ b/python/grpc_opentracing/_server.py
@@ -1,4 +1,4 @@
-"""Implementation of the server-side open-tracing interceptor."""
+"""Implementation of the service-side open-tracing interceptor."""
 
 import sys
 import logging

--- a/python/grpc_opentracing/_server.py
+++ b/python/grpc_opentracing/_server.py
@@ -8,7 +8,7 @@ from six import iteritems
 
 import grpc
 from grpc_opentracing import grpcext, ActiveSpanSource, ServerRequestAttribute
-from grpc_opentracing._utilities import get_method_type
+from grpc_opentracing._utilities import get_method_type, get_deadline_millis
 import opentracing
 
 
@@ -141,6 +141,9 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
                                                    is_server_stream)
       elif traced_attribute == ServerRequestAttribute.METHOD_NAME:
         tags['grpc.method_name'] = method
+      elif traced_attribute == ServerRequestAttribute.DEADLINE:
+        tags['grpc.deadline_millis'] = get_deadline_millis(
+            servicer_context.time_remaining())
       else:
         logging.warning('OpenTracing Attribute \"%s\" is not supported',
                         str(traced_attribute))

--- a/python/grpc_opentracing/_server.py
+++ b/python/grpc_opentracing/_server.py
@@ -180,12 +180,13 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
   # For RPCs that stream responses, the result can be a generator. To record
   # the span across the generated responses and detect any errors, we wrap the
   # result in a new generator that yields the response values.
-  def _intercept_server_stream(self, servicer_context, server_info, handler):
+  def _intercept_server_stream(self, request_or_iterator, servicer_context,
+                               server_info, handler):
     with self._start_span(servicer_context, server_info.full_method,
                           server_info.is_client_stream, True) as span:
       servicer_context = _OpenTracingServicerContext(servicer_context, span)
       try:
-        result = handler(servicer_context)
+        result = handler(request_or_iterator, servicer_context)
         for response in result:
           yield response
       except:
@@ -195,10 +196,11 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
         raise
       _check_error_code(span, servicer_context)
 
-  def intercept_stream(self, servicer_context, server_info, handler):
+  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
+                       handler):
     if server_info.is_server_stream:
-      return self._intercept_server_stream(servicer_context, server_info,
-                                           handler)
+      return self._intercept_server_stream(
+          request_or_iterator, servicer_context, server_info, handler)
     with self._start_span(servicer_context, server_info.full_method,
                           server_info.is_client_stream, False) as span:
       # The invocation-side may have invoked this RPC asynchronously; in which
@@ -209,7 +211,7 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
       servicer_context = _OpenTracingServicerContext(servicer_context, span,
                                                      trailing_metadata)
       try:
-        result = handler(servicer_context)
+        result = handler(request_or_iterator, servicer_context)
       except:
         e = sys.exc_info()[0]
         span.set_tag('error', True)

--- a/python/grpc_opentracing/_server.py
+++ b/python/grpc_opentracing/_server.py
@@ -18,6 +18,8 @@ class _OpenTracingServicerContext(grpc.ServicerContext, ActiveSpanSource):
     self._servicer_context = servicer_context
     self._active_span = active_span
     self._trailing_metadata = trailing_metadata
+    self.code = grpc.StatusCode.OK
+    self.details = None
 
   def is_active(self, *args, **kwargs):
     return self._servicer_context.is_active(*args, **kwargs)
@@ -53,9 +55,11 @@ class _OpenTracingServicerContext(grpc.ServicerContext, ActiveSpanSource):
     return self._servicer_context.set_trailing_metadata(trailing_metadata)
 
   def set_code(self, code):
+    self.code = code
     return self._servicer_context.set_code(code)
 
   def set_details(self, details):
+    self.details = details
     return self._servicer_context.set_details(details)
 
   def get_active_span(self):
@@ -91,6 +95,18 @@ def _inject_span_context(tracer, span, servicer_context):
   metadata = tuple(iteritems(headers))
   servicer_context.set_trailing_metadata(metadata)
   return metadata
+
+
+# On the service-side, errors can be signaled either by exceptions or by calling
+# `set_code` on the `servicer_context`. This function checks for the latter and
+# updates the span accordingly.
+def _check_error_code(span, servicer_context):
+  if servicer_context.code != grpc.StatusCode.OK:
+    span.set_tag('error', True)
+    error_log = {'event': 'error', 'error.kind': str(servicer_context.code)}
+    if servicer_context.details is not None:
+      error_log['message'] = servicer_context.details
+    span.log_kv(error_log)
 
 
 class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
@@ -139,15 +155,15 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
                           False) as span:
       if self._log_payloads:
         span.log_kv({'request': request})
+      # The invocation-side may have invoked this RPC asynchronously; in which
+      # case, it may want to reference the servicer-side's span context, so
+      # we send it back in the trailing_metadata
+      trailing_metadata = _inject_span_context(self._tracer, span,
+                                               servicer_context)
+      servicer_context = _OpenTracingServicerContext(servicer_context, span,
+                                                     trailing_metadata)
       try:
-        # The invocation-side may have invoked this RPC asynchronously; in which
-        # case, it may want to reference the servicer-side's span context, so
-        # we send it back in the trailing_metadata
-        trailing_metadata = _inject_span_context(self._tracer, span,
-                                                 servicer_context)
-        response = handler(request,
-                           _OpenTracingServicerContext(servicer_context, span,
-                                                       trailing_metadata))
+        response = handler(request, servicer_context)
       except:
         e = sys.exc_info()[0]
         span.set_tag('error', True)
@@ -155,6 +171,7 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
         raise
       if self._log_payloads:
         span.log_kv({'response': response})
+      _check_error_code(span, servicer_context)
       return response
 
   # For RPCs that stream responses, the result can be a generator. To record
@@ -163,8 +180,9 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
   def _intercept_server_stream(self, servicer_context, server_info, handler):
     with self._start_span(servicer_context, server_info.full_method,
                           server_info.is_client_stream, True) as span:
+      servicer_context = _OpenTracingServicerContext(servicer_context, span)
       try:
-        result = handler(_OpenTracingServicerContext(servicer_context, span))
+        result = handler(servicer_context)
         for response in result:
           yield response
       except:
@@ -172,6 +190,7 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
         span.set_tag('error', True)
         span.log_kv({'event': 'error', 'error.object': e})
         raise
+      _check_error_code(span, servicer_context)
 
   def intercept_stream(self, servicer_context, server_info, handler):
     if server_info.is_server_stream:
@@ -179,17 +198,19 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
                                            handler)
     with self._start_span(servicer_context, server_info.full_method,
                           server_info.is_client_stream, False) as span:
+      # The invocation-side may have invoked this RPC asynchronously; in which
+      # case, it may want to reference the servicer-side's span context, so
+      # we send it back in the trailing_metadata
+      trailing_metadata = _inject_span_context(self._tracer, span,
+                                               servicer_context)
+      servicer_context = _OpenTracingServicerContext(servicer_context, span,
+                                                     trailing_metadata)
       try:
-        # The invocation-side may have invoked this RPC asynchronously; in which
-        # case, it may want to reference the servicer-side's span context, so
-        # we send it back in the trailing_metadata
-        trailing_metadata = _inject_span_context(self._tracer, span,
-                                                 servicer_context)
-        return handler(
-            _OpenTracingServicerContext(servicer_context, span,
-                                        trailing_metadata))
+        result = handler(servicer_context)
       except:
         e = sys.exc_info()[0]
         span.set_tag('error', True)
         span.log_kv({'event': 'error', 'error.object': e})
         raise
+      _check_error_code(span, servicer_context)
+      return result

--- a/python/grpc_opentracing/_utilities.py
+++ b/python/grpc_opentracing/_utilities.py
@@ -14,5 +14,5 @@ def get_method_type(is_client_stream, is_server_stream):
 
 def get_deadline_millis(timeout):
   if timeout is None:
-    return 'null'
-  return str(int(round(float(timeout) * 1000)))
+    return 'None'
+  return str(int(round(timeout * 1000)))

--- a/python/grpc_opentracing/_utilities.py
+++ b/python/grpc_opentracing/_utilities.py
@@ -1,0 +1,12 @@
+"""Internal utilities for gRPC OpenTracing."""
+
+
+def get_method_type(is_client_stream, is_server_stream):
+  if is_client_stream and is_server_stream:
+    return 'BIDI_STREAMING'
+  elif is_client_stream:
+    return 'CLIENT_STREAMING'
+  elif is_server_stream:
+    return 'SERVER_STREAMING'
+  else:
+    return 'UNARY'

--- a/python/grpc_opentracing/_utilities.py
+++ b/python/grpc_opentracing/_utilities.py
@@ -2,44 +2,44 @@
 
 
 def get_method_type(is_client_stream, is_server_stream):
-  if is_client_stream and is_server_stream:
-    return 'BIDI_STREAMING'
-  elif is_client_stream:
-    return 'CLIENT_STREAMING'
-  elif is_server_stream:
-    return 'SERVER_STREAMING'
-  else:
-    return 'UNARY'
+    if is_client_stream and is_server_stream:
+        return 'BIDI_STREAMING'
+    elif is_client_stream:
+        return 'CLIENT_STREAMING'
+    elif is_server_stream:
+        return 'SERVER_STREAMING'
+    else:
+        return 'UNARY'
 
 
 def get_deadline_millis(timeout):
-  if timeout is None:
-    return 'None'
-  return str(int(round(timeout * 1000)))
+    if timeout is None:
+        return 'None'
+    return str(int(round(timeout * 1000)))
 
 
 class _RequestLoggingIterator(object):
 
-  def __init__(self, request_iterator, span):
-    self._request_iterator = request_iterator
-    self._span = span
+    def __init__(self, request_iterator, span):
+        self._request_iterator = request_iterator
+        self._span = span
 
-  def __iter__(self):
-    return self
+    def __iter__(self):
+        return self
 
-  def next(self):
-    request = next(self._request_iterator)
-    self._span.log_kv({'request': request})
-    return request
+    def next(self):
+        request = next(self._request_iterator)
+        self._span.log_kv({'request': request})
+        return request
 
-  def __next__(self):
-    return self.next()
+    def __next__(self):
+        return self.next()
 
 
 def log_or_wrap_request_or_iterator(span, is_client_stream,
                                     request_or_iterator):
-  if is_client_stream:
-    return _RequestLoggingIterator(request_or_iterator, span)
-  else:
-    span.log_kv({'request': request_or_iterator})
-    return request_or_iterator
+    if is_client_stream:
+        return _RequestLoggingIterator(request_or_iterator, span)
+    else:
+        span.log_kv({'request': request_or_iterator})
+        return request_or_iterator

--- a/python/grpc_opentracing/_utilities.py
+++ b/python/grpc_opentracing/_utilities.py
@@ -10,3 +10,9 @@ def get_method_type(is_client_stream, is_server_stream):
     return 'SERVER_STREAMING'
   else:
     return 'UNARY'
+
+
+def get_deadline_millis(timeout):
+  if timeout is None:
+    return 'null'
+  return str(int(round(float(timeout) * 1000)))

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -4,7 +4,7 @@ import six
 
 
 class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a unary RPC on the client-side.
+  """Consists of various information about a unary RPC on the invocation-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -16,13 +16,14 @@ class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a client-side, unary-unary RPC method is called.
+  """Invokes custom code when an invocation-side, unary-unary RPC method is
+    called.
   """
 
   @abc.abstractmethod
   def intercept_unary(self, request, metadata, client_info, invoker):
-    """A function to be called when a client-side, unary-unary RPC method is
-          invoked.
+    """A function to be called when an invocation-side, unary-unary RPC method 
+      is invoked.
 
     Args:
       request: The request value for the RPC.
@@ -40,7 +41,7 @@ class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a stream RPC on the client-side.
+  """Consists of various information about a stream RPC on the invocation-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -54,14 +55,14 @@ class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a client-side, unary-stream, stream-unary, or
-      stream-stream RPC method is called.
+  """Invokes custom code when an invocation-side, unary-stream, stream-unary, or
+    stream-stream RPC method is called.
   """
 
   @abc.abstractmethod
   def intercept_stream(self, metadata, client_info, invoker):
-    """A function to be called when a client-side, unary-stream,
-          stream-unary, or stream-stream RPC method is invoked.
+    """A function to be called when an invocation-side, unary-stream,
+      stream-unary, or stream-stream RPC method is invoked.
 
     Args:
       metadata: Optional :term:`metadata` to be transmitted to the service-side
@@ -98,7 +99,7 @@ def intercept_channel(channel, *interceptors):
 
 
 class UnaryServerInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a unary RPC on the server-side.
+  """Consists of various information about a unary RPC on the service-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -106,7 +107,7 @@ class UnaryServerInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamServerInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a stream RPC on the server-side.
+  """Consists of various information about a stream RPC on the service-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -116,13 +117,13 @@ class StreamServerInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a server-side, unary-unary RPC method is called.
+  """Invokes custom code when a service-side, unary-unary RPC method is called.
   """
 
   @abc.abstractmethod
   def intercept_unary(self, request, servicer_context, server_info, handler):
-    """A function to be called when a server-side, unary-unary RPC method is
-          invoked.
+    """A function to be called when a service-side, unary-unary RPC method is
+      invoked.
 
     Args:
       request: The request value for the RPC.
@@ -139,13 +140,13 @@ class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a server-side, unary-stream, stream-unary, or
-      stream-stream, RPC method is called.
+  """Invokes custom code when a service-side, unary-stream, stream-unary, or
+    stream-stream, RPC method is called.
   """
 
   @abc.abstractmethod
   def intercept_stream(self, servicer_context, server_info, handler):
-    """A function to be called when a server-side, unary-stream,
+    """A function to be called when a service-side, unary-stream,
       stream-unary, or stream-stream RPC method is invoked.
 
     Args:

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -6,77 +6,74 @@ import six
 class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
   """Consists of various information about a unary RPC on the client-side.
 
-    Attributes:
-      full_method: A string of the full RPC method, i.e.,
-        /package.service/method.
-      timeout: The length of time in seconds to wait for the computation to
-        terminate or be cancelled, or None if this method should block until
-        the computation is terminated or is cancelled no matter how long that
-        takes.
-    """
+  Attributes:
+    full_method: A string of the full RPC method, i.e., /package.service/method.
+    timeout: The length of time in seconds to wait for the computation to
+      terminate or be cancelled, or None if this method should block until
+      the computation is terminated or is cancelled no matter how long that
+      takes.
+  """
 
 
 class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a client-side, unary-unary RPC method is
-      called.
-    """
+  """Invokes custom code when a client-side, unary-unary RPC method is called.
+  """
 
   @abc.abstractmethod
   def intercept_unary(self, request, metadata, client_info, invoker):
     """A function to be called when a client-side, unary-unary RPC method is
           invoked.
 
-        Args:
-          request: The request value for the RPC.
-          metadata: Optional :term:`metadata` to be transmitted to the
-            service-side of the RPC.
-          client_info: A UnaryClientInfo containing various information about
-            the RPC.
-          invoker:  The handler to complete the RPC on the client. It is the
-            interceptor's responsibility to call it.
+    Args:
+      request: The request value for the RPC.
+      metadata: Optional :term:`metadata` to be transmitted to the
+        service-side of the RPC.
+      client_info: A UnaryClientInfo containing various information about
+        the RPC.
+      invoker: The handler to complete the RPC on the client. It is the
+        interceptor's responsibility to call it.
 
-        Returns:
-          The result from calling invoker(request, metadata).
-        """
+    Returns:
+      The result from calling invoker(request, metadata).
+    """
     raise NotImplementedError()
 
 
 class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
   """Consists of various information about a stream RPC on the client-side.
 
-    Attributes:
-      full_method: A string of the full RPC method, i.e.,
-        /package.service/method.
-      is_client_stream: Indicates whether the RPC is client-streaming.
-      is_server_stream: Indicates whether the RPC is server-streaming.
-      timeout: The length of time in seconds to wait for the computation to
-        terminate or be cancelled, or None if this method should block until
-        the computation is terminated or is cancelled no matter how long that
-        takes.
-    """
+  Attributes:
+    full_method: A string of the full RPC method, i.e., /package.service/method.
+    is_client_stream: Indicates whether the RPC is client-streaming.
+    is_server_stream: Indicates whether the RPC is server-streaming.
+    timeout: The length of time in seconds to wait for the computation to
+      terminate or be cancelled, or None if this method should block until
+      the computation is terminated or is cancelled no matter how long that
+      takes.
+  """
 
 
 class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
   """Invokes custom code when a client-side, unary-stream, stream-unary, or
       stream-stream RPC method is called.
-    """
+  """
 
   @abc.abstractmethod
   def intercept_stream(self, metadata, client_info, invoker):
     """A function to be called when a client-side, unary-stream,
           stream-unary, or stream-stream RPC method is invoked.
 
-        Args:
-          metadata: Optional :term:`metadata` to be transmitted to the
-            service-side of the RPC.
-          client_info: A StreamClientInfo containing various information about
-            the RPC.
-          invoker:  The handler to complete the RPC on the client. It is the
-            interceptor's responsibility to call it.
+    Args:
+      metadata: Optional :term:`metadata` to be transmitted to the service-side
+        of the RPC.
+      client_info: A StreamClientInfo containing various information about
+        the RPC.
+      invoker:  The handler to complete the RPC on the client. It is the
+        interceptor's responsibility to call it.
 
-        Returns:
-          The result from calling invoker(metadata).
-        """
+      Returns:
+        The result from calling invoker(metadata).
+    """
     raise NotImplementedError()
 
 
@@ -84,17 +81,17 @@ def intercept_channel(channel, *interceptors):
   """Creates a new Channel that invokes the given interceptors if their
     targeted RPC types are called.
 
-    Args:
-      channel: A Channel.
-      interceptors: Zero or more UnaryClientInterceptors or
-        StreamClientInterceptors
+  Args:
+    channel: A Channel.
+    interceptors: Zero or more UnaryClientInterceptors or
+      StreamClientInterceptors
 
-    Returns:
-      A Channel.
+  Returns:
+    A Channel.
 
-    Raises:
-      TypeError: If an interceptor derives from neither UnaryClientInterceptor
-        nor StreamClientInterceptor.
+  Raises:
+    TypeError: If an interceptor derives from neither UnaryClientInterceptor
+      nor StreamClientInterceptor.
   """
   from grpc_opentracing.grpcext import _interceptor
   return _interceptor.intercept_channel(channel, *interceptors)
@@ -103,67 +100,64 @@ def intercept_channel(channel, *interceptors):
 class UnaryServerInfo(six.with_metaclass(abc.ABCMeta)):
   """Consists of various information about a unary RPC on the server-side.
 
-    Attributes:
-      full_method: A string of the full RPC method, i.e.,
-        /package.service/method.
-    """
+  Attributes:
+    full_method: A string of the full RPC method, i.e., /package.service/method.
+  """
 
 
 class StreamServerInfo(six.with_metaclass(abc.ABCMeta)):
   """Consists of various information about a stream RPC on the server-side.
 
-    Attributes:
-      full_method: A string of the full RPC method, i.e.,
-        /package.service/method.
-      is_client_stream: Indicates whether the RPC is client-streaming.
-      is_server_stream: Indicates whether the RPC is server-streaming.
-    """
+  Attributes:
+    full_method: A string of the full RPC method, i.e., /package.service/method.
+    is_client_stream: Indicates whether the RPC is client-streaming.
+    is_server_stream: Indicates whether the RPC is server-streaming.
+  """
 
 
 class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a server-side, unary-unary RPC method is
-      called.
-    """
+  """Invokes custom code when a server-side, unary-unary RPC method is called.
+  """
 
   @abc.abstractmethod
   def intercept_unary(self, request, servicer_context, server_info, handler):
     """A function to be called when a server-side, unary-unary RPC method is
           invoked.
 
-        Args:
-          request: The request value for the RPC.
-          servicer_context: A ServicerContext.
-          server_info: A UnaryServerInfo containing various information about
-            the RPC.
-          handler:  The handler to complete the RPC on the server. It is the
-            interceptor's responsibility to call it.
+    Args:
+      request: The request value for the RPC.
+      servicer_context: A ServicerContext.
+      server_info: A UnaryServerInfo containing various information about
+        the RPC.
+      handler:  The handler to complete the RPC on the server. It is the
+        interceptor's responsibility to call it.
 
-        Returns:
-          The result from calling handler(request, servicer_context).
-        """
+    Returns:
+      The result from calling handler(request, servicer_context).
+    """
     raise NotImplementedError()
 
 
 class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
   """Invokes custom code when a server-side, unary-stream, stream-unary, or
       stream-stream, RPC method is called.
-    """
+  """
 
   @abc.abstractmethod
   def intercept_stream(self, servicer_context, server_info, handler):
     """A function to be called when a server-side, unary-stream,
-          stream-unary, or stream-stream RPC method is invoked.
+      stream-unary, or stream-stream RPC method is invoked.
 
-        Args:
-          servicer_context: A ServicerContext.
-          server_info: A StreamServerInfo containing various information about
-            the RPC.
-          handler:  The handler to complete the RPC on the server. It is the
-            interceptor's responsibility to call it.
+    Args:
+      servicer_context: A ServicerContext.
+      server_info: A StreamServerInfo containing various information about
+        the RPC.
+      handler:  The handler to complete the RPC on the server. It is the
+        interceptor's responsibility to call it.
 
-        Returns:
-          The result from calling handler(servicer_context).
-        """
+      Returns:
+        The result from calling handler(servicer_context).
+    """
     raise NotImplementedError()
 
 
@@ -171,17 +165,17 @@ def intercept_server(server, *interceptors):
   """Creates a new Channel that invokes the given interceptors if their
     targeted RPC types are called.
 
-    Args:
-      server: A Server.
-      interceptors: Zero or more UnaryServerInterceptors or
-        StreamServerInterceptors
+  Args:
+    server: A Server.
+    interceptors: Zero or more UnaryServerInterceptors or
+      StreamServerInterceptors
 
-    Returns:
-      A Server.
+  Returns:
+    A Server.
 
-    Raises:
-      TypeError: If an interceptor derives from neither UnaryServerInterceptor
-        nor StreamServerInterceptor.
+  Raises:
+    TypeError: If an interceptor derives from neither UnaryServerInterceptor
+      nor StreamServerInterceptor.
   """
   from grpc_opentracing.grpcext import _interceptor
   return _interceptor.intercept_server(server, *interceptors)

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -4,7 +4,7 @@ import six
 
 
 class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a unary RPC on the invocation-side.
+    """Consists of various information about a unary RPC on the invocation-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -16,7 +16,7 @@ class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a stream RPC on the invocation-side.
+    """Consists of various information about a stream RPC on the invocation-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -30,11 +30,11 @@ class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Affords intercepting unary-unary RPCs on the invocation-side."""
+    """Affords intercepting unary-unary RPCs on the invocation-side."""
 
-  @abc.abstractmethod
-  def intercept_unary(self, request, metadata, client_info, invoker):
-    """Intercepts unary-unary RPCs on the invocation-side.
+    @abc.abstractmethod
+    def intercept_unary(self, request, metadata, client_info, invoker):
+        """Intercepts unary-unary RPCs on the invocation-side.
 
     Args:
       request: The request value for the RPC.
@@ -48,16 +48,16 @@ class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
     Returns:
       The result from calling invoker(request, metadata).
     """
-    raise NotImplementedError()
+        raise NotImplementedError()
 
 
 class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Affords intercepting stream RPCs on the invocation-side."""
+    """Affords intercepting stream RPCs on the invocation-side."""
 
-  @abc.abstractmethod
-  def intercept_stream(self, request_or_iterator, metadata, client_info,
-                       invoker):
-    """Intercepts stream RPCs on the invocation-side.
+    @abc.abstractmethod
+    def intercept_stream(self, request_or_iterator, metadata, client_info,
+                         invoker):
+        """Intercepts stream RPCs on the invocation-side.
 
     Args:
       request_or_iterator: The request value for the RPC if
@@ -73,11 +73,11 @@ class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
       Returns:
         The result from calling invoker(metadata).
     """
-    raise NotImplementedError()
+        raise NotImplementedError()
 
 
 def intercept_channel(channel, *interceptors):
-  """Creates an intercepted channel.
+    """Creates an intercepted channel.
 
   Args:
     channel: A Channel.
@@ -91,12 +91,12 @@ def intercept_channel(channel, *interceptors):
     TypeError: If an interceptor derives from neither UnaryClientInterceptor
       nor StreamClientInterceptor.
   """
-  from grpc_opentracing.grpcext import _interceptor
-  return _interceptor.intercept_channel(channel, *interceptors)
+    from grpc_opentracing.grpcext import _interceptor
+    return _interceptor.intercept_channel(channel, *interceptors)
 
 
 class UnaryServerInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a unary RPC on the service-side.
+    """Consists of various information about a unary RPC on the service-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -104,7 +104,7 @@ class UnaryServerInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamServerInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a stream RPC on the service-side.
+    """Consists of various information about a stream RPC on the service-side.
 
   Attributes:
     full_method: A string of the full RPC method, i.e., /package.service/method.
@@ -114,11 +114,11 @@ class StreamServerInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Affords intercepting unary-unary RPCs on the service-side."""
+    """Affords intercepting unary-unary RPCs on the service-side."""
 
-  @abc.abstractmethod
-  def intercept_unary(self, request, servicer_context, server_info, handler):
-    """Intercepts unary-unary RPCs on the service-side.
+    @abc.abstractmethod
+    def intercept_unary(self, request, servicer_context, server_info, handler):
+        """Intercepts unary-unary RPCs on the service-side.
 
     Args:
       request: The request value for the RPC.
@@ -131,16 +131,16 @@ class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
     Returns:
       The result from calling handler(request, servicer_context).
     """
-    raise NotImplementedError()
+        raise NotImplementedError()
 
 
 class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Affords intercepting stream RPCs on the service-side."""
+    """Affords intercepting stream RPCs on the service-side."""
 
-  @abc.abstractmethod
-  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
-                       handler):
-    """Intercepts stream RPCs on the service-side.
+    @abc.abstractmethod
+    def intercept_stream(self, request_or_iterator, servicer_context,
+                         server_info, handler):
+        """Intercepts stream RPCs on the service-side.
 
     Args:
       request_or_iterator: The request value for the RPC if
@@ -155,11 +155,11 @@ class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
       Returns:
         The result from calling handler(servicer_context).
     """
-    raise NotImplementedError()
+        raise NotImplementedError()
 
 
 def intercept_server(server, *interceptors):
-  """Creates an intercepted server.
+    """Creates an intercepted server.
 
   Args:
     server: A Server.
@@ -173,8 +173,8 @@ def intercept_server(server, *interceptors):
     TypeError: If an interceptor derives from neither UnaryServerInterceptor
       nor StreamServerInterceptor.
   """
-  from grpc_opentracing.grpcext import _interceptor
-  return _interceptor.intercept_server(server, *interceptors)
+    from grpc_opentracing.grpcext import _interceptor
+    return _interceptor.intercept_server(server, *interceptors)
 
 
 ###################################  __all__  #################################

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -3,21 +3,35 @@ import abc
 import six
 
 
+class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
+  """Consists of various information about a unary RPC on the client-side.
+
+    Attributes:
+      full_method: A string of the full RPC method, i.e.,
+        /package.service/method.
+      timeout: The length of time in seconds to wait for the computation to
+        terminate or be cancelled, or None if this method should block until
+        the computation is terminated or is cancelled no matter how long that
+        takes.
+    """
+
+
 class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
   """Invokes custom code when a client-side, unary-unary RPC method is
       called.
     """
 
   @abc.abstractmethod
-  def intercept_unary(self, method, request, metadata, invoker):
+  def intercept_unary(self, request, metadata, client_info, invoker):
     """A function to be called when a client-side, unary-unary RPC method is
           invoked.
 
         Args:
-          method: A string of the fully qualified method name being called.
           request: The request value for the RPC.
           metadata: Optional :term:`metadata` to be transmitted to the
             service-side of the RPC.
+          client_info: A UnaryClientInfo containing various information about
+            the RPC.
           invoker:  The handler to complete the RPC on the client. It is the
             interceptor's responsibility to call it.
 
@@ -35,6 +49,10 @@ class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
         /package.service/method.
       is_client_stream: Indicates whether the RPC is client-streaming.
       is_server_stream: Indicates whether the RPC is server-streaming.
+      timeout: The length of time in seconds to wait for the computation to
+        terminate or be cancelled, or None if this method should block until
+        the computation is terminated or is cancelled no matter how long that
+        takes.
     """
 
 

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -60,11 +60,15 @@ class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
   """
 
   @abc.abstractmethod
-  def intercept_stream(self, metadata, client_info, invoker):
+  def intercept_stream(self, request_or_iterator, metadata, client_info,
+                       invoker):
     """A function to be called when an invocation-side, unary-stream,
       stream-unary, or stream-stream RPC method is invoked.
 
     Args:
+      request_or_iterator: The request value for the RPC if
+        `client_info.is_client_stream` is `false`; otherwise, an iterator of
+        request values.
       metadata: Optional :term:`metadata` to be transmitted to the service-side
         of the RPC.
       client_info: A StreamClientInfo containing various information about
@@ -145,11 +149,15 @@ class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
   """
 
   @abc.abstractmethod
-  def intercept_stream(self, servicer_context, server_info, handler):
+  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
+                       handler):
     """A function to be called when a service-side, unary-stream,
       stream-unary, or stream-stream RPC method is invoked.
 
     Args:
+      request_or_iterator: The request value for the RPC if
+        `server_info.is_client_stream` is `false`; otherwise, an iterator of
+        request values.
       servicer_context: A ServicerContext.
       server_info: A StreamServerInfo containing various information about
         the RPC.

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -15,15 +15,26 @@ class UnaryClientInfo(six.with_metaclass(abc.ABCMeta)):
   """
 
 
-class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when an invocation-side, unary-unary RPC method is
-    called.
+class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
+  """Consists of various information about a stream RPC on the invocation-side.
+
+  Attributes:
+    full_method: A string of the full RPC method, i.e., /package.service/method.
+    is_client_stream: Indicates whether the RPC is client-streaming.
+    is_server_stream: Indicates whether the RPC is server-streaming.
+    timeout: The length of time in seconds to wait for the computation to
+      terminate or be cancelled, or None if this method should block until
+      the computation is terminated or is cancelled no matter how long that
+      takes.
   """
+
+
+class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
+  """Affords intercepting unary-unary RPCs on the invocation-side."""
 
   @abc.abstractmethod
   def intercept_unary(self, request, metadata, client_info, invoker):
-    """A function to be called when an invocation-side, unary-unary RPC method 
-      is invoked.
+    """Intercepts unary-unary RPCs on the invocation-side.
 
     Args:
       request: The request value for the RPC.
@@ -40,30 +51,13 @@ class UnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
     raise NotImplementedError()
 
 
-class StreamClientInfo(six.with_metaclass(abc.ABCMeta)):
-  """Consists of various information about a stream RPC on the invocation-side.
-
-  Attributes:
-    full_method: A string of the full RPC method, i.e., /package.service/method.
-    is_client_stream: Indicates whether the RPC is client-streaming.
-    is_server_stream: Indicates whether the RPC is server-streaming.
-    timeout: The length of time in seconds to wait for the computation to
-      terminate or be cancelled, or None if this method should block until
-      the computation is terminated or is cancelled no matter how long that
-      takes.
-  """
-
-
 class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when an invocation-side, unary-stream, stream-unary, or
-    stream-stream RPC method is called.
-  """
+  """Affords intercepting stream RPCs on the invocation-side."""
 
   @abc.abstractmethod
   def intercept_stream(self, request_or_iterator, metadata, client_info,
                        invoker):
-    """A function to be called when an invocation-side, unary-stream,
-      stream-unary, or stream-stream RPC method is invoked.
+    """Intercepts stream RPCs on the invocation-side.
 
     Args:
       request_or_iterator: The request value for the RPC if
@@ -83,8 +77,7 @@ class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
 
 
 def intercept_channel(channel, *interceptors):
-  """Creates a new Channel that invokes the given interceptors if their
-    targeted RPC types are called.
+  """Creates an intercepted channel.
 
   Args:
     channel: A Channel.
@@ -121,13 +114,11 @@ class StreamServerInfo(six.with_metaclass(abc.ABCMeta)):
 
 
 class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a service-side, unary-unary RPC method is called.
-  """
+  """Affords intercepting unary-unary RPCs on the service-side."""
 
   @abc.abstractmethod
   def intercept_unary(self, request, servicer_context, server_info, handler):
-    """A function to be called when a service-side, unary-unary RPC method is
-      invoked.
+    """Intercepts unary-unary RPCs on the service-side.
 
     Args:
       request: The request value for the RPC.
@@ -144,19 +135,16 @@ class UnaryServerInterceptor(six.with_metaclass(abc.ABCMeta)):
 
 
 class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
-  """Invokes custom code when a service-side, unary-stream, stream-unary, or
-    stream-stream, RPC method is called.
-  """
+  """Affords intercepting stream RPCs on the service-side."""
 
   @abc.abstractmethod
   def intercept_stream(self, request_or_iterator, servicer_context, server_info,
                        handler):
-    """A function to be called when a service-side, unary-stream,
-      stream-unary, or stream-stream RPC method is invoked.
+    """Intercepts stream RPCs on the service-side.
 
     Args:
       request_or_iterator: The request value for the RPC if
-        `server_info.is_client_stream` is `false`; otherwise, an iterator of
+        `server_info.is_client_stream` is `False`; otherwise, an iterator of
         request values.
       servicer_context: A ServicerContext.
       server_info: A StreamServerInfo containing various information about
@@ -171,8 +159,7 @@ class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
 
 
 def intercept_server(server, *interceptors):
-  """Creates a new Channel that invokes the given interceptors if their
-    targeted RPC types are called.
+  """Creates an intercepted server.
 
   Args:
     server: A Server.

--- a/python/grpc_opentracing/grpcext/_interceptor.py
+++ b/python/grpc_opentracing/grpcext/_interceptor.py
@@ -62,11 +62,12 @@ class _InterceptorUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
 
   def __call__(self, request, timeout=None, metadata=None, credentials=None):
 
-    def invoker(metadata):
+    def invoker(request, metadata):
       return self._base_callable(request, timeout, metadata, credentials)
 
     client_info = _StreamClientInfo(self._method, False, True, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request, metadata, client_info,
+                                              invoker)
 
 
 class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
@@ -82,12 +83,13 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                metadata=None,
                credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable(request_iterator, timeout, metadata,
                                  credentials)
 
     client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
   def with_call(self,
                 request_iterator,
@@ -95,12 +97,13 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                 metadata=None,
                 credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable.with_call(request_iterator, timeout, metadata,
                                            credentials)
 
     client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
   def future(self,
              request_iterator,
@@ -108,12 +111,13 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
              metadata=None,
              credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable.future(request_iterator, timeout, metadata,
                                         credentials)
 
     client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
 
 class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
@@ -129,12 +133,13 @@ class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
                metadata=None,
                credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable(request_iterator, timeout, metadata,
                                  credentials)
 
     client_info = _StreamClientInfo(self._method, True, True, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
 
 class _InterceptorChannel(grpc.Channel):
@@ -267,11 +272,11 @@ class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
     def adaptation(request, servicer_context):
 
-      def handler(servicer_context):
+      def handler(request, servicer_context):
         return self._rpc_method_handler.unary_stream(request, servicer_context)
 
       return self._interceptor.intercept_stream(
-          servicer_context,
+          request, servicer_context,
           _StreamServerInfo(self._method, False, True), handler)
 
     return adaptation
@@ -283,12 +288,12 @@ class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
     def adaptation(request_iterator, servicer_context):
 
-      def handler(servicer_context):
+      def handler(request_iterator, servicer_context):
         return self._rpc_method_handler.stream_unary(request_iterator,
                                                      servicer_context)
 
       return self._interceptor.intercept_stream(
-          servicer_context,
+          request_iterator, servicer_context,
           _StreamServerInfo(self._method, True, False), handler)
 
     return adaptation
@@ -300,13 +305,13 @@ class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
     def adaptation(request_iterator, servicer_context):
 
-      def handler(servicer_context):
+      def handler(request_iterator, servicer_context):
         return self._rpc_method_handler.stream_stream(request_iterator,
                                                       servicer_context)
 
       return self._interceptor.intercept_stream(
-          servicer_context, _StreamServerInfo(self._method, True, True),
-          handler)
+          request_iterator, servicer_context,
+          _StreamServerInfo(self._method, True, True), handler)
 
     return adaptation
 

--- a/python/grpc_opentracing/grpcext/_interceptor.py
+++ b/python/grpc_opentracing/grpcext/_interceptor.py
@@ -7,362 +7,367 @@ from grpc_opentracing import grpcext
 
 
 class _UnaryClientInfo(
-    collections.namedtuple('_UnaryClientInfo', ('full_method', 'timeout',))):
-  pass
+        collections.namedtuple('_UnaryClientInfo',
+                               ('full_method', 'timeout',))):
+    pass
 
 
 class _StreamClientInfo(
-    collections.namedtuple('_StreamClientInfo', (
-        'full_method', 'is_client_stream', 'is_server_stream', 'timeout'))):
-  pass
+        collections.namedtuple('_StreamClientInfo', (
+            'full_method', 'is_client_stream', 'is_server_stream', 'timeout'))):
+    pass
 
 
 class _InterceptorUnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
 
-  def __init__(self, method, base_callable, interceptor):
-    self._method = method
-    self._base_callable = base_callable
-    self._interceptor = interceptor
+    def __init__(self, method, base_callable, interceptor):
+        self._method = method
+        self._base_callable = base_callable
+        self._interceptor = interceptor
 
-  def __call__(self, request, timeout=None, metadata=None, credentials=None):
+    def __call__(self, request, timeout=None, metadata=None, credentials=None):
 
-    def invoker(request, metadata):
-      return self._base_callable(request, timeout, metadata, credentials)
+        def invoker(request, metadata):
+            return self._base_callable(request, timeout, metadata, credentials)
 
-    client_info = _UnaryClientInfo(self._method, timeout)
-    return self._interceptor.intercept_unary(request, metadata, client_info,
-                                             invoker)
+        client_info = _UnaryClientInfo(self._method, timeout)
+        return self._interceptor.intercept_unary(request, metadata, client_info,
+                                                 invoker)
 
-  def with_call(self, request, timeout=None, metadata=None, credentials=None):
+    def with_call(self, request, timeout=None, metadata=None, credentials=None):
 
-    def invoker(request, metadata):
-      return self._base_callable.with_call(request, timeout, metadata,
-                                           credentials)
+        def invoker(request, metadata):
+            return self._base_callable.with_call(request, timeout, metadata,
+                                                 credentials)
 
-    client_info = _UnaryClientInfo(self._method, timeout)
-    return self._interceptor.intercept_unary(request, metadata, client_info,
-                                             invoker)
+        client_info = _UnaryClientInfo(self._method, timeout)
+        return self._interceptor.intercept_unary(request, metadata, client_info,
+                                                 invoker)
 
-  def future(self, request, timeout=None, metadata=None, credentials=None):
+    def future(self, request, timeout=None, metadata=None, credentials=None):
 
-    def invoker(request, metadata):
-      return self._base_callable.future(request, timeout, metadata, credentials)
+        def invoker(request, metadata):
+            return self._base_callable.future(request, timeout, metadata,
+                                              credentials)
 
-    client_info = _UnaryClientInfo(self._method, timeout)
-    return self._interceptor.intercept_unary(request, metadata, client_info,
-                                             invoker)
+        client_info = _UnaryClientInfo(self._method, timeout)
+        return self._interceptor.intercept_unary(request, metadata, client_info,
+                                                 invoker)
 
 
 class _InterceptorUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
 
-  def __init__(self, method, base_callable, interceptor):
-    self._method = method
-    self._base_callable = base_callable
-    self._interceptor = interceptor
+    def __init__(self, method, base_callable, interceptor):
+        self._method = method
+        self._base_callable = base_callable
+        self._interceptor = interceptor
 
-  def __call__(self, request, timeout=None, metadata=None, credentials=None):
+    def __call__(self, request, timeout=None, metadata=None, credentials=None):
 
-    def invoker(request, metadata):
-      return self._base_callable(request, timeout, metadata, credentials)
+        def invoker(request, metadata):
+            return self._base_callable(request, timeout, metadata, credentials)
 
-    client_info = _StreamClientInfo(self._method, False, True, timeout)
-    return self._interceptor.intercept_stream(request, metadata, client_info,
-                                              invoker)
+        client_info = _StreamClientInfo(self._method, False, True, timeout)
+        return self._interceptor.intercept_stream(request, metadata,
+                                                  client_info, invoker)
 
 
 class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
 
-  def __init__(self, method, base_callable, interceptor):
-    self._method = method
-    self._base_callable = base_callable
-    self._interceptor = interceptor
+    def __init__(self, method, base_callable, interceptor):
+        self._method = method
+        self._base_callable = base_callable
+        self._interceptor = interceptor
 
-  def __call__(self,
+    def __call__(self,
+                 request_iterator,
+                 timeout=None,
+                 metadata=None,
+                 credentials=None):
+
+        def invoker(request_iterator, metadata):
+            return self._base_callable(request_iterator, timeout, metadata,
+                                       credentials)
+
+        client_info = _StreamClientInfo(self._method, True, False, timeout)
+        return self._interceptor.intercept_stream(request_iterator, metadata,
+                                                  client_info, invoker)
+
+    def with_call(self,
+                  request_iterator,
+                  timeout=None,
+                  metadata=None,
+                  credentials=None):
+
+        def invoker(request_iterator, metadata):
+            return self._base_callable.with_call(request_iterator, timeout,
+                                                 metadata, credentials)
+
+        client_info = _StreamClientInfo(self._method, True, False, timeout)
+        return self._interceptor.intercept_stream(request_iterator, metadata,
+                                                  client_info, invoker)
+
+    def future(self,
                request_iterator,
                timeout=None,
                metadata=None,
                credentials=None):
 
-    def invoker(request_iterator, metadata):
-      return self._base_callable(request_iterator, timeout, metadata,
-                                 credentials)
+        def invoker(request_iterator, metadata):
+            return self._base_callable.future(request_iterator, timeout,
+                                              metadata, credentials)
 
-    client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(request_iterator, metadata,
-                                              client_info, invoker)
-
-  def with_call(self,
-                request_iterator,
-                timeout=None,
-                metadata=None,
-                credentials=None):
-
-    def invoker(request_iterator, metadata):
-      return self._base_callable.with_call(request_iterator, timeout, metadata,
-                                           credentials)
-
-    client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(request_iterator, metadata,
-                                              client_info, invoker)
-
-  def future(self,
-             request_iterator,
-             timeout=None,
-             metadata=None,
-             credentials=None):
-
-    def invoker(request_iterator, metadata):
-      return self._base_callable.future(request_iterator, timeout, metadata,
-                                        credentials)
-
-    client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(request_iterator, metadata,
-                                              client_info, invoker)
+        client_info = _StreamClientInfo(self._method, True, False, timeout)
+        return self._interceptor.intercept_stream(request_iterator, metadata,
+                                                  client_info, invoker)
 
 
 class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
 
-  def __init__(self, method, base_callable, interceptor):
-    self._method = method
-    self._base_callable = base_callable
-    self._interceptor = interceptor
+    def __init__(self, method, base_callable, interceptor):
+        self._method = method
+        self._base_callable = base_callable
+        self._interceptor = interceptor
 
-  def __call__(self,
-               request_iterator,
-               timeout=None,
-               metadata=None,
-               credentials=None):
+    def __call__(self,
+                 request_iterator,
+                 timeout=None,
+                 metadata=None,
+                 credentials=None):
 
-    def invoker(request_iterator, metadata):
-      return self._base_callable(request_iterator, timeout, metadata,
-                                 credentials)
+        def invoker(request_iterator, metadata):
+            return self._base_callable(request_iterator, timeout, metadata,
+                                       credentials)
 
-    client_info = _StreamClientInfo(self._method, True, True, timeout)
-    return self._interceptor.intercept_stream(request_iterator, metadata,
-                                              client_info, invoker)
+        client_info = _StreamClientInfo(self._method, True, True, timeout)
+        return self._interceptor.intercept_stream(request_iterator, metadata,
+                                                  client_info, invoker)
 
 
 class _InterceptorChannel(grpc.Channel):
 
-  def __init__(self, channel, interceptor):
-    self._channel = channel
-    self._interceptor = interceptor
+    def __init__(self, channel, interceptor):
+        self._channel = channel
+        self._interceptor = interceptor
 
-  def subscribe(self, *args, **kwargs):
-    self._channel.subscribe(*args, **kwargs)
+    def subscribe(self, *args, **kwargs):
+        self._channel.subscribe(*args, **kwargs)
 
-  def unsubscribe(self, *args, **kwargs):
-    self._channel.unsubscribe(*args, **kwargs)
+    def unsubscribe(self, *args, **kwargs):
+        self._channel.unsubscribe(*args, **kwargs)
 
-  def unary_unary(self,
-                  method,
-                  request_serializer=None,
-                  response_deserializer=None):
-    base_callable = self._channel.unary_unary(method, request_serializer,
-                                              response_deserializer)
-    if isinstance(self._interceptor, grpcext.UnaryClientInterceptor):
-      return _InterceptorUnaryUnaryMultiCallable(method, base_callable,
-                                                 self._interceptor)
-    else:
-      return base_callable
-
-  def unary_stream(self,
-                   method,
-                   request_serializer=None,
-                   response_deserializer=None):
-    base_callable = self._channel.unary_stream(method, request_serializer,
-                                               response_deserializer)
-    if isinstance(self._interceptor, grpcext.StreamClientInterceptor):
-      return _InterceptorUnaryStreamMultiCallable(method, base_callable,
-                                                  self._interceptor)
-    else:
-      return base_callable
-
-  def stream_unary(self,
-                   method,
-                   request_serializer=None,
-                   response_deserializer=None):
-    base_callable = self._channel.stream_unary(method, request_serializer,
-                                               response_deserializer)
-    if isinstance(self._interceptor, grpcext.StreamClientInterceptor):
-      return _InterceptorStreamUnaryMultiCallable(method, base_callable,
-                                                  self._interceptor)
-    else:
-      return base_callable
-
-  def stream_stream(self,
+    def unary_unary(self,
                     method,
                     request_serializer=None,
                     response_deserializer=None):
-    base_callable = self._channel.stream_stream(method, request_serializer,
-                                                response_deserializer)
-    if isinstance(self._interceptor, grpcext.StreamClientInterceptor):
-      return _InterceptorStreamStreamMultiCallable(method, base_callable,
-                                                   self._interceptor)
-    else:
-      return base_callable
+        base_callable = self._channel.unary_unary(method, request_serializer,
+                                                  response_deserializer)
+        if isinstance(self._interceptor, grpcext.UnaryClientInterceptor):
+            return _InterceptorUnaryUnaryMultiCallable(method, base_callable,
+                                                       self._interceptor)
+        else:
+            return base_callable
+
+    def unary_stream(self,
+                     method,
+                     request_serializer=None,
+                     response_deserializer=None):
+        base_callable = self._channel.unary_stream(method, request_serializer,
+                                                   response_deserializer)
+        if isinstance(self._interceptor, grpcext.StreamClientInterceptor):
+            return _InterceptorUnaryStreamMultiCallable(method, base_callable,
+                                                        self._interceptor)
+        else:
+            return base_callable
+
+    def stream_unary(self,
+                     method,
+                     request_serializer=None,
+                     response_deserializer=None):
+        base_callable = self._channel.stream_unary(method, request_serializer,
+                                                   response_deserializer)
+        if isinstance(self._interceptor, grpcext.StreamClientInterceptor):
+            return _InterceptorStreamUnaryMultiCallable(method, base_callable,
+                                                        self._interceptor)
+        else:
+            return base_callable
+
+    def stream_stream(self,
+                      method,
+                      request_serializer=None,
+                      response_deserializer=None):
+        base_callable = self._channel.stream_stream(method, request_serializer,
+                                                    response_deserializer)
+        if isinstance(self._interceptor, grpcext.StreamClientInterceptor):
+            return _InterceptorStreamStreamMultiCallable(method, base_callable,
+                                                         self._interceptor)
+        else:
+            return base_callable
 
 
 def intercept_channel(channel, *interceptors):
-  result = channel
-  for interceptor in interceptors:
-    if not isinstance(interceptor, grpcext.UnaryClientInterceptor) and \
-       not isinstance(interceptor, grpcext.StreamClientInterceptor):
-      raise TypeError('interceptor must be either a '
-                      'grpcext.UnaryClientInterceptor or a '
-                      'grpcext.StreamClientInterceptor')
-    result = _InterceptorChannel(result, interceptor)
-  return result
+    result = channel
+    for interceptor in interceptors:
+        if not isinstance(interceptor, grpcext.UnaryClientInterceptor) and \
+           not isinstance(interceptor, grpcext.StreamClientInterceptor):
+            raise TypeError('interceptor must be either a '
+                            'grpcext.UnaryClientInterceptor or a '
+                            'grpcext.StreamClientInterceptor')
+        result = _InterceptorChannel(result, interceptor)
+    return result
 
 
 class _UnaryServerInfo(
-    collections.namedtuple('_UnaryServerInfo', ('full_method',))):
-  pass
+        collections.namedtuple('_UnaryServerInfo', ('full_method',))):
+    pass
 
 
 class _StreamServerInfo(
-    collections.namedtuple('_StreamServerInfo', (
-        'full_method', 'is_client_stream', 'is_server_stream'))):
-  pass
+        collections.namedtuple('_StreamServerInfo', (
+            'full_method', 'is_client_stream', 'is_server_stream'))):
+    pass
 
 
 class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
-  def __init__(self, rpc_method_handler, method, interceptor):
-    self._rpc_method_handler = rpc_method_handler
-    self._method = method
-    self._interceptor = interceptor
+    def __init__(self, rpc_method_handler, method, interceptor):
+        self._rpc_method_handler = rpc_method_handler
+        self._method = method
+        self._interceptor = interceptor
 
-  @property
-  def request_streaming(self):
-    return self._rpc_method_handler.request_streaming
+    @property
+    def request_streaming(self):
+        return self._rpc_method_handler.request_streaming
 
-  @property
-  def response_streaming(self):
-    return self._rpc_method_handler.response_streaming
+    @property
+    def response_streaming(self):
+        return self._rpc_method_handler.response_streaming
 
-  @property
-  def request_deserializer(self):
-    return self._rpc_method_handler.request_deserializer
+    @property
+    def request_deserializer(self):
+        return self._rpc_method_handler.request_deserializer
 
-  @property
-  def response_serializer(self):
-    return self._rpc_method_handler.response_serializer
+    @property
+    def response_serializer(self):
+        return self._rpc_method_handler.response_serializer
 
-  @property
-  def unary_unary(self):
-    if not isinstance(self._interceptor, grpcext.UnaryServerInterceptor):
-      return self._rpc_method_handler.unary_unary
+    @property
+    def unary_unary(self):
+        if not isinstance(self._interceptor, grpcext.UnaryServerInterceptor):
+            return self._rpc_method_handler.unary_unary
 
-    def adaptation(request, servicer_context):
+        def adaptation(request, servicer_context):
 
-      def handler(request, servicer_context):
-        return self._rpc_method_handler.unary_unary(request, servicer_context)
+            def handler(request, servicer_context):
+                return self._rpc_method_handler.unary_unary(request,
+                                                            servicer_context)
 
-      return self._interceptor.intercept_unary(request, servicer_context,
-                                               _UnaryServerInfo(self._method),
-                                               handler)
+            return self._interceptor.intercept_unary(
+                request, servicer_context,
+                _UnaryServerInfo(self._method), handler)
 
-    return adaptation
+        return adaptation
 
-  @property
-  def unary_stream(self):
-    if not isinstance(self._interceptor, grpcext.StreamServerInterceptor):
-      return self._rpc_method_handler.unary_stream
+    @property
+    def unary_stream(self):
+        if not isinstance(self._interceptor, grpcext.StreamServerInterceptor):
+            return self._rpc_method_handler.unary_stream
 
-    def adaptation(request, servicer_context):
+        def adaptation(request, servicer_context):
 
-      def handler(request, servicer_context):
-        return self._rpc_method_handler.unary_stream(request, servicer_context)
+            def handler(request, servicer_context):
+                return self._rpc_method_handler.unary_stream(request,
+                                                             servicer_context)
 
-      return self._interceptor.intercept_stream(
-          request, servicer_context,
-          _StreamServerInfo(self._method, False, True), handler)
+            return self._interceptor.intercept_stream(
+                request, servicer_context,
+                _StreamServerInfo(self._method, False, True), handler)
 
-    return adaptation
+        return adaptation
 
-  @property
-  def stream_unary(self):
-    if not isinstance(self._interceptor, grpcext.StreamServerInterceptor):
-      return self._rpc_method_handler.stream_unary
+    @property
+    def stream_unary(self):
+        if not isinstance(self._interceptor, grpcext.StreamServerInterceptor):
+            return self._rpc_method_handler.stream_unary
 
-    def adaptation(request_iterator, servicer_context):
+        def adaptation(request_iterator, servicer_context):
 
-      def handler(request_iterator, servicer_context):
-        return self._rpc_method_handler.stream_unary(request_iterator,
-                                                     servicer_context)
+            def handler(request_iterator, servicer_context):
+                return self._rpc_method_handler.stream_unary(request_iterator,
+                                                             servicer_context)
 
-      return self._interceptor.intercept_stream(
-          request_iterator, servicer_context,
-          _StreamServerInfo(self._method, True, False), handler)
+            return self._interceptor.intercept_stream(
+                request_iterator, servicer_context,
+                _StreamServerInfo(self._method, True, False), handler)
 
-    return adaptation
+        return adaptation
 
-  @property
-  def stream_stream(self):
-    if not isinstance(self._interceptor, grpcext.StreamServerInterceptor):
-      return self._rpc_method_handler.stream_stream
+    @property
+    def stream_stream(self):
+        if not isinstance(self._interceptor, grpcext.StreamServerInterceptor):
+            return self._rpc_method_handler.stream_stream
 
-    def adaptation(request_iterator, servicer_context):
+        def adaptation(request_iterator, servicer_context):
 
-      def handler(request_iterator, servicer_context):
-        return self._rpc_method_handler.stream_stream(request_iterator,
-                                                      servicer_context)
+            def handler(request_iterator, servicer_context):
+                return self._rpc_method_handler.stream_stream(request_iterator,
+                                                              servicer_context)
 
-      return self._interceptor.intercept_stream(
-          request_iterator, servicer_context,
-          _StreamServerInfo(self._method, True, True), handler)
+            return self._interceptor.intercept_stream(
+                request_iterator, servicer_context,
+                _StreamServerInfo(self._method, True, True), handler)
 
-    return adaptation
+        return adaptation
 
 
 class _InterceptorGenericRpcHandler(grpc.GenericRpcHandler):
 
-  def __init__(self, generic_rpc_handler, interceptor):
-    self.generic_rpc_handler = generic_rpc_handler
-    self._interceptor = interceptor
+    def __init__(self, generic_rpc_handler, interceptor):
+        self.generic_rpc_handler = generic_rpc_handler
+        self._interceptor = interceptor
 
-  def service(self, handler_call_details):
-    result = self.generic_rpc_handler.service(handler_call_details)
-    if result:
-      result = _InterceptorRpcMethodHandler(result, handler_call_details.method,
-                                            self._interceptor)
-    return result
+    def service(self, handler_call_details):
+        result = self.generic_rpc_handler.service(handler_call_details)
+        if result:
+            result = _InterceptorRpcMethodHandler(
+                result, handler_call_details.method, self._interceptor)
+        return result
 
 
 class _InterceptorServer(grpc.Server):
 
-  def __init__(self, server, interceptor):
-    self._server = server
-    self._interceptor = interceptor
+    def __init__(self, server, interceptor):
+        self._server = server
+        self._interceptor = interceptor
 
-  def add_generic_rpc_handlers(self, generic_rpc_handlers):
-    generic_rpc_handlers = [
-        _InterceptorGenericRpcHandler(generic_rpc_handler, self._interceptor)
-        for generic_rpc_handler in generic_rpc_handlers
-    ]
-    return self._server.add_generic_rpc_handlers(generic_rpc_handlers)
+    def add_generic_rpc_handlers(self, generic_rpc_handlers):
+        generic_rpc_handlers = [
+            _InterceptorGenericRpcHandler(generic_rpc_handler,
+                                          self._interceptor)
+            for generic_rpc_handler in generic_rpc_handlers
+        ]
+        return self._server.add_generic_rpc_handlers(generic_rpc_handlers)
 
-  def add_insecure_port(self, *args, **kwargs):
-    return self._server.add_insecure_port(*args, **kwargs)
+    def add_insecure_port(self, *args, **kwargs):
+        return self._server.add_insecure_port(*args, **kwargs)
 
-  def add_secure_port(self, *args, **kwargs):
-    return self._server.add_secure_port(*args, **kwargs)
+    def add_secure_port(self, *args, **kwargs):
+        return self._server.add_secure_port(*args, **kwargs)
 
-  def start(self, *args, **kwargs):
-    return self._server.start(*args, **kwargs)
+    def start(self, *args, **kwargs):
+        return self._server.start(*args, **kwargs)
 
-  def stop(self, *args, **kwargs):
-    return self._server.stop(*args, **kwargs)
+    def stop(self, *args, **kwargs):
+        return self._server.stop(*args, **kwargs)
 
 
 def intercept_server(server, *interceptors):
-  result = server
-  for interceptor in interceptors:
-    if not isinstance(interceptor, grpcext.UnaryServerInterceptor) and \
-       not isinstance(interceptor, grpcext.StreamServerInterceptor):
-      raise TypeError('interceptor must be either a '
-                      'grpcext.UnaryServerInterceptor or a '
-                      'grpcext.StreamServerInterceptor')
-    result = _InterceptorServer(result, interceptor)
-  return result
+    result = server
+    for interceptor in interceptors:
+        if not isinstance(interceptor, grpcext.UnaryServerInterceptor) and \
+           not isinstance(interceptor, grpcext.StreamServerInterceptor):
+            raise TypeError('interceptor must be either a '
+                            'grpcext.UnaryServerInterceptor or a '
+                            'grpcext.StreamServerInterceptor')
+        result = _InterceptorServer(result, interceptor)
+    return result

--- a/python/tests/_service.py
+++ b/python/tests/_service.py
@@ -1,5 +1,7 @@
 """Creates a simple service on top of gRPC for testing."""
 
+from builtins import input, range
+
 import grpc
 from grpc.framework.foundation import logging_pool
 from grpc_opentracing import grpcext
@@ -54,7 +56,7 @@ class Handler(object):
       self.invocation_metadata = servicer_context.invocation_metadata()
       if self.trailing_metadata is not None:
         servicer_context.set_trailing_metadata(self.trailing_metadata)
-    for _ in xrange(_STREAM_LENGTH):
+    for _ in range(_STREAM_LENGTH):
       yield request
 
   def handle_stream_unary(self, request_iterator, servicer_context):

--- a/python/tests/_service.py
+++ b/python/tests/_service.py
@@ -38,17 +38,37 @@ class _MethodHandler(grpc.RpcMethodHandler):
 
 class Handler(object):
 
+  def __init__(self):
+    self.invocation_metadata = None
+    self.trailing_metadata = None
+
   def handle_unary_unary(self, request, servicer_context):
+    if servicer_context is not None:
+      self.invocation_metadata = servicer_context.invocation_metadata()
+      if self.trailing_metadata is not None:
+        servicer_context.set_trailing_metadata(self.trailing_metadata)
     return request
 
   def handle_unary_stream(self, request, servicer_context):
+    if servicer_context is not None:
+      self.invocation_metadata = servicer_context.invocation_metadata()
+      if self.trailing_metadata is not None:
+        servicer_context.set_trailing_metadata(self.trailing_metadata)
     for _ in xrange(_STREAM_LENGTH):
       yield request
 
   def handle_stream_unary(self, request_iterator, servicer_context):
+    if servicer_context is not None:
+      self.invocation_metadata = servicer_context.invocation_metadata()
+      if self.trailing_metadata is not None:
+        servicer_context.set_trailing_metadata(self.trailing_metadata)
     return b''.join(list(request_iterator))
 
   def handle_stream_stream(self, request_iterator, servicer_context):
+    if servicer_context is not None:
+      self.invocation_metadata = servicer_context.invocation_metadata()
+      if self.trailing_metadata is not None:
+        servicer_context.set_trailing_metadata(self.trailing_metadata)
     for request in request_iterator:
       yield request
 
@@ -59,6 +79,9 @@ def _set_error_code(servicer_context):
 
 
 class ErroringHandler(Handler):
+
+  def __init__(self):
+    super(ErroringHandler, self).__init__()
 
   def handle_unary_unary(self, request, servicer_context):
     _set_error_code(servicer_context)
@@ -82,6 +105,9 @@ class ErroringHandler(Handler):
 
 
 class ExceptionErroringHandler(Handler):
+
+  def __init__(self):
+    super(ExceptionErroringHandler, self).__init__()
 
   def handle_unary_unary(self, request, servicer_context):
     raise IndexError()

--- a/python/tests/_service.py
+++ b/python/tests/_service.py
@@ -21,172 +21,172 @@ _STREAM_LENGTH = 5
 
 class _MethodHandler(grpc.RpcMethodHandler):
 
-  def __init__(self,
-               request_streaming=False,
-               response_streaming=False,
-               unary_unary=None,
-               unary_stream=None,
-               stream_unary=None,
-               stream_stream=None):
-    self.request_streaming = request_streaming
-    self.response_streaming = response_streaming
-    self.request_deserializer = _DESERIALIZE_REQUEST
-    self.response_serializer = _SERIALIZE_RESPONSE
-    self.unary_unary = unary_unary
-    self.unary_stream = unary_stream
-    self.stream_unary = stream_unary
-    self.stream_stream = stream_stream
+    def __init__(self,
+                 request_streaming=False,
+                 response_streaming=False,
+                 unary_unary=None,
+                 unary_stream=None,
+                 stream_unary=None,
+                 stream_stream=None):
+        self.request_streaming = request_streaming
+        self.response_streaming = response_streaming
+        self.request_deserializer = _DESERIALIZE_REQUEST
+        self.response_serializer = _SERIALIZE_RESPONSE
+        self.unary_unary = unary_unary
+        self.unary_stream = unary_stream
+        self.stream_unary = stream_unary
+        self.stream_stream = stream_stream
 
 
 class Handler(object):
 
-  def __init__(self):
-    self.invocation_metadata = None
-    self.trailing_metadata = None
+    def __init__(self):
+        self.invocation_metadata = None
+        self.trailing_metadata = None
 
-  def handle_unary_unary(self, request, servicer_context):
-    if servicer_context is not None:
-      self.invocation_metadata = servicer_context.invocation_metadata()
-      if self.trailing_metadata is not None:
-        servicer_context.set_trailing_metadata(self.trailing_metadata)
-    return request
+    def handle_unary_unary(self, request, servicer_context):
+        if servicer_context is not None:
+            self.invocation_metadata = servicer_context.invocation_metadata()
+            if self.trailing_metadata is not None:
+                servicer_context.set_trailing_metadata(self.trailing_metadata)
+        return request
 
-  def handle_unary_stream(self, request, servicer_context):
-    if servicer_context is not None:
-      self.invocation_metadata = servicer_context.invocation_metadata()
-      if self.trailing_metadata is not None:
-        servicer_context.set_trailing_metadata(self.trailing_metadata)
-    for _ in range(_STREAM_LENGTH):
-      yield request
+    def handle_unary_stream(self, request, servicer_context):
+        if servicer_context is not None:
+            self.invocation_metadata = servicer_context.invocation_metadata()
+            if self.trailing_metadata is not None:
+                servicer_context.set_trailing_metadata(self.trailing_metadata)
+        for _ in range(_STREAM_LENGTH):
+            yield request
 
-  def handle_stream_unary(self, request_iterator, servicer_context):
-    if servicer_context is not None:
-      self.invocation_metadata = servicer_context.invocation_metadata()
-      if self.trailing_metadata is not None:
-        servicer_context.set_trailing_metadata(self.trailing_metadata)
-    return b''.join(list(request_iterator))
+    def handle_stream_unary(self, request_iterator, servicer_context):
+        if servicer_context is not None:
+            self.invocation_metadata = servicer_context.invocation_metadata()
+            if self.trailing_metadata is not None:
+                servicer_context.set_trailing_metadata(self.trailing_metadata)
+        return b''.join(list(request_iterator))
 
-  def handle_stream_stream(self, request_iterator, servicer_context):
-    if servicer_context is not None:
-      self.invocation_metadata = servicer_context.invocation_metadata()
-      if self.trailing_metadata is not None:
-        servicer_context.set_trailing_metadata(self.trailing_metadata)
-    for request in request_iterator:
-      yield request
+    def handle_stream_stream(self, request_iterator, servicer_context):
+        if servicer_context is not None:
+            self.invocation_metadata = servicer_context.invocation_metadata()
+            if self.trailing_metadata is not None:
+                servicer_context.set_trailing_metadata(self.trailing_metadata)
+        for request in request_iterator:
+            yield request
 
 
 def _set_error_code(servicer_context):
-  servicer_context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-  servicer_context.set_details('ErroringHandler')
+    servicer_context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+    servicer_context.set_details('ErroringHandler')
 
 
 class ErroringHandler(Handler):
 
-  def __init__(self):
-    super(ErroringHandler, self).__init__()
+    def __init__(self):
+        super(ErroringHandler, self).__init__()
 
-  def handle_unary_unary(self, request, servicer_context):
-    _set_error_code(servicer_context)
-    return super(ErroringHandler, self).handle_unary_unary(request,
-                                                           servicer_context)
+    def handle_unary_unary(self, request, servicer_context):
+        _set_error_code(servicer_context)
+        return super(ErroringHandler, self).handle_unary_unary(request,
+                                                               servicer_context)
 
-  def handle_unary_stream(self, request, servicer_context):
-    _set_error_code(servicer_context)
-    return super(ErroringHandler, self).handle_unary_stream(request,
-                                                            servicer_context)
+    def handle_unary_stream(self, request, servicer_context):
+        _set_error_code(servicer_context)
+        return super(ErroringHandler, self).handle_unary_stream(
+            request, servicer_context)
 
-  def handle_stream_unary(self, request_iterator, servicer_context):
-    _set_error_code(servicer_context)
-    return super(ErroringHandler, self).handle_stream_unary(request_iterator,
-                                                            servicer_context)
+    def handle_stream_unary(self, request_iterator, servicer_context):
+        _set_error_code(servicer_context)
+        return super(ErroringHandler, self).handle_stream_unary(
+            request_iterator, servicer_context)
 
-  def handle_stream_stream(self, request_iterator, servicer_context):
-    _set_error_code(servicer_context)
-    return super(ErroringHandler, self).handle_stream_stream(request_iterator,
-                                                             servicer_context)
+    def handle_stream_stream(self, request_iterator, servicer_context):
+        _set_error_code(servicer_context)
+        return super(ErroringHandler, self).handle_stream_stream(
+            request_iterator, servicer_context)
 
 
 class ExceptionErroringHandler(Handler):
 
-  def __init__(self):
-    super(ExceptionErroringHandler, self).__init__()
+    def __init__(self):
+        super(ExceptionErroringHandler, self).__init__()
 
-  def handle_unary_unary(self, request, servicer_context):
-    raise IndexError()
+    def handle_unary_unary(self, request, servicer_context):
+        raise IndexError()
 
-  def handle_unary_stream(self, request, servicer_context):
-    raise IndexError()
+    def handle_unary_stream(self, request, servicer_context):
+        raise IndexError()
 
-  def handle_stream_unary(self, request_iterator, servicer_context):
-    raise IndexError()
+    def handle_stream_unary(self, request_iterator, servicer_context):
+        raise IndexError()
 
-  def handle_stream_stream(self, request_iterator, servicer_context):
-    raise IndexError()
+    def handle_stream_stream(self, request_iterator, servicer_context):
+        raise IndexError()
 
 
 class _GenericHandler(grpc.GenericRpcHandler):
 
-  def __init__(self, handler):
-    self._handler = handler
+    def __init__(self, handler):
+        self._handler = handler
 
-  def service(self, handler_call_details):
-    method = handler_call_details.method
-    if method == _UNARY_UNARY:
-      return _MethodHandler(unary_unary=self._handler.handle_unary_unary)
-    elif method == _UNARY_STREAM:
-      return _MethodHandler(
-          response_streaming=True,
-          unary_stream=self._handler.handle_unary_stream)
-    elif method == _STREAM_UNARY:
-      return _MethodHandler(
-          request_streaming=True,
-          stream_unary=self._handler.handle_stream_unary)
-    elif method == _STREAM_STREAM:
-      return _MethodHandler(
-          request_streaming=True,
-          response_streaming=True,
-          stream_stream=self._handler.handle_stream_stream)
-    else:
-      return None
+    def service(self, handler_call_details):
+        method = handler_call_details.method
+        if method == _UNARY_UNARY:
+            return _MethodHandler(unary_unary=self._handler.handle_unary_unary)
+        elif method == _UNARY_STREAM:
+            return _MethodHandler(
+                response_streaming=True,
+                unary_stream=self._handler.handle_unary_stream)
+        elif method == _STREAM_UNARY:
+            return _MethodHandler(
+                request_streaming=True,
+                stream_unary=self._handler.handle_stream_unary)
+        elif method == _STREAM_STREAM:
+            return _MethodHandler(
+                request_streaming=True,
+                response_streaming=True,
+                stream_stream=self._handler.handle_stream_stream)
+        else:
+            return None
 
 
 class Service(object):
 
-  def __init__(self,
-               client_interceptors,
-               server_interceptors,
-               handler=Handler()):
-    self.handler = handler
-    self._server_pool = logging_pool.pool(2)
-    self._server = grpcext.intercept_server(
-        grpc.server(self._server_pool), *server_interceptors)
-    port = self._server.add_insecure_port('[::]:0')
-    self._server.add_generic_rpc_handlers((_GenericHandler(self.handler),))
-    self._server.start()
-    self.channel = grpcext.intercept_channel(
-        grpc.insecure_channel('localhost:%d' % port), *client_interceptors)
+    def __init__(self,
+                 client_interceptors,
+                 server_interceptors,
+                 handler=Handler()):
+        self.handler = handler
+        self._server_pool = logging_pool.pool(2)
+        self._server = grpcext.intercept_server(
+            grpc.server(self._server_pool), *server_interceptors)
+        port = self._server.add_insecure_port('[::]:0')
+        self._server.add_generic_rpc_handlers((_GenericHandler(self.handler),))
+        self._server.start()
+        self.channel = grpcext.intercept_channel(
+            grpc.insecure_channel('localhost:%d' % port), *client_interceptors)
 
-  @property
-  def unary_unary_multi_callable(self):
-    return self.channel.unary_unary(_UNARY_UNARY)
+    @property
+    def unary_unary_multi_callable(self):
+        return self.channel.unary_unary(_UNARY_UNARY)
 
-  @property
-  def unary_stream_multi_callable(self):
-    return self.channel.unary_stream(
-        _UNARY_STREAM,
-        request_serializer=_SERIALIZE_REQUEST,
-        response_deserializer=_DESERIALIZE_RESPONSE)
+    @property
+    def unary_stream_multi_callable(self):
+        return self.channel.unary_stream(
+            _UNARY_STREAM,
+            request_serializer=_SERIALIZE_REQUEST,
+            response_deserializer=_DESERIALIZE_RESPONSE)
 
-  @property
-  def stream_unary_multi_callable(self):
-    return self.channel.stream_unary(
-        _STREAM_UNARY,
-        request_serializer=_SERIALIZE_REQUEST,
-        response_deserializer=_DESERIALIZE_RESPONSE)
+    @property
+    def stream_unary_multi_callable(self):
+        return self.channel.stream_unary(
+            _STREAM_UNARY,
+            request_serializer=_SERIALIZE_REQUEST,
+            response_deserializer=_DESERIALIZE_RESPONSE)
 
-  @property
-  def stream_stream_multi_callable(self):
-    return self.channel.stream_stream(
-        _STREAM_STREAM,
-        request_serializer=_SERIALIZE_REQUEST,
-        response_deserializer=_DESERIALIZE_RESPONSE)
+    @property
+    def stream_stream_multi_callable(self):
+        return self.channel.stream_stream(
+            _STREAM_STREAM,
+            request_serializer=_SERIALIZE_REQUEST,
+            response_deserializer=_DESERIALIZE_RESPONSE)

--- a/python/tests/_service.py
+++ b/python/tests/_service.py
@@ -81,6 +81,21 @@ class ErroringHandler(Handler):
                                                              servicer_context)
 
 
+class ExceptionErroringHandler(Handler):
+
+  def handle_unary_unary(self, request, servicer_context):
+    raise IndexError()
+
+  def handle_unary_stream(self, request, servicer_context):
+    raise IndexError()
+
+  def handle_stream_unary(self, request_iterator, servicer_context):
+    raise IndexError()
+
+  def handle_stream_stream(self, request_iterator, servicer_context):
+    raise IndexError()
+
+
 class _GenericHandler(grpc.GenericRpcHandler):
 
   def __init__(self, handler):

--- a/python/tests/_tracer.py
+++ b/python/tests/_tracer.py
@@ -6,75 +6,78 @@ import opentracing
 
 @enum.unique
 class SpanRelationship(enum.Enum):
-  NONE = 0
-  FOLLOWS_FROM = 1
-  CHILD_OF = 2
+    NONE = 0
+    FOLLOWS_FROM = 1
+    CHILD_OF = 2
 
 
 class _SpanContext(opentracing.SpanContext):
 
-  def __init__(self, identity):
-    self.identity = identity
+    def __init__(self, identity):
+        self.identity = identity
 
 
 class _Span(opentracing.Span):
 
-  def __init__(self, tracer, identity, tags=None):
-    super(_Span, self).__init__(tracer, _SpanContext(identity))
-    self._identity = identity
-    if tags is None:
-      tags = {}
-    self._tags = tags
+    def __init__(self, tracer, identity, tags=None):
+        super(_Span, self).__init__(tracer, _SpanContext(identity))
+        self._identity = identity
+        if tags is None:
+            tags = {}
+        self._tags = tags
 
-  def set_tag(self, key, value):
-    self._tags[key] = value
+    def set_tag(self, key, value):
+        self._tags[key] = value
 
-  def get_tag(self, key):
-    return self._tags.get(key, None)
+    def get_tag(self, key):
+        return self._tags.get(key, None)
 
 
 class Tracer(opentracing.Tracer):
 
-  def __init__(self):
-    super(Tracer, self).__init__()
-    self._counter = 0
-    self._spans = {}
-    self._relationships = defaultdict(lambda: None)
+    def __init__(self):
+        super(Tracer, self).__init__()
+        self._counter = 0
+        self._spans = {}
+        self._relationships = defaultdict(lambda: None)
 
-  def start_span(self,
-                 operation_name=None,
-                 child_of=None,
-                 references=None,
-                 tags=None,
-                 start_time=None):
-    identity = self._counter
-    self._counter += 1
-    if child_of is not None:
-      self._relationships[(child_of.identity,
-                           identity)] = opentracing.ReferenceType.CHILD_OF
-    if references is not None:
-      assert child_of is None and len(
-          references) == 1, 'Only a single reference is supported'
-      reference_type, span_context = references[0]
-      self._relationships[(span_context.identity, identity)] = reference_type
-    span = _Span(self, identity, tags)
-    self._spans[identity] = span
-    return span
+    def start_span(self,
+                   operation_name=None,
+                   child_of=None,
+                   references=None,
+                   tags=None,
+                   start_time=None):
+        identity = self._counter
+        self._counter += 1
+        if child_of is not None:
+            self._relationships[(child_of.identity,
+                                 identity)] = opentracing.ReferenceType.CHILD_OF
+        if references is not None:
+            assert child_of is None and len(
+                references) == 1, 'Only a single reference is supported'
+            reference_type, span_context = references[0]
+            self._relationships[(span_context.identity,
+                                 identity)] = reference_type
+        span = _Span(self, identity, tags)
+        self._spans[identity] = span
+        return span
 
-  def inject(self, span_context, format, carrier):
-    if format != opentracing.Format.HTTP_HEADERS and isinstance(carrier, dict):
-      raise opentracing.UnsupportedFormatException(format)
-    carrier['span-identity'] = str(span_context.identity)
+    def inject(self, span_context, format, carrier):
+        if format != opentracing.Format.HTTP_HEADERS and isinstance(carrier,
+                                                                    dict):
+            raise opentracing.UnsupportedFormatException(format)
+        carrier['span-identity'] = str(span_context.identity)
 
-  def extract(self, format, carrier):
-    if format != opentracing.Format.HTTP_HEADERS and isinstance(carrier, dict):
-      raise opentracing.UnsupportedFormatException(format)
-    if 'span-identity' not in carrier:
-      raise opentracing.SpanContextCorruptedException
-    return _SpanContext(int(carrier['span-identity']))
+    def extract(self, format, carrier):
+        if format != opentracing.Format.HTTP_HEADERS and isinstance(carrier,
+                                                                    dict):
+            raise opentracing.UnsupportedFormatException(format)
+        if 'span-identity' not in carrier:
+            raise opentracing.SpanContextCorruptedException
+        return _SpanContext(int(carrier['span-identity']))
 
-  def get_relationship(self, identity1, identity2):
-    return self._relationships[(identity1, identity2)]
+    def get_relationship(self, identity1, identity2):
+        return self._relationships[(identity1, identity2)]
 
-  def get_span(self, identity):
-    return self._spans.get(identity, None)
+    def get_span(self, identity):
+        return self._spans.get(identity, None)

--- a/python/tests/_tracer.py
+++ b/python/tests/_tracer.py
@@ -39,7 +39,7 @@ class Tracer(opentracing.Tracer):
     super(Tracer, self).__init__()
     self._counter = 0
     self._spans = {}
-    self._relationships = defaultdict(lambda: SpanRelationship.NONE)
+    self._relationships = defaultdict(lambda: None)
 
   def start_span(self,
                  operation_name=None,
@@ -51,7 +51,12 @@ class Tracer(opentracing.Tracer):
     self._counter += 1
     if child_of is not None:
       self._relationships[(child_of.identity,
-                           identity)] = SpanRelationship.CHILD_OF
+                           identity)] = opentracing.ReferenceType.CHILD_OF
+    if references is not None:
+      assert child_of is None and len(
+          references) == 1, 'Only a single reference is supported'
+      reference_type, span_context = references[0]
+      self._relationships[(span_context.identity, identity)] = reference_type
     span = _Span(self, identity, tags)
     self._spans[identity] = span
     return span

--- a/python/tests/test_interceptor.py
+++ b/python/tests/test_interceptor.py
@@ -16,9 +16,10 @@ class ClientInterceptor(grpcext.UnaryClientInterceptor,
     self.intercepted = True
     return invoker(request, metadata)
 
-  def intercept_stream(self, metadata, client_info, invoker):
+  def intercept_stream(self, request_or_iterator, metadata, client_info,
+                       invoker):
     self.intercepted = True
-    return invoker(metadata)
+    return invoker(request_or_iterator, metadata)
 
 
 class ServerInterceptor(grpcext.UnaryServerInterceptor,
@@ -31,9 +32,10 @@ class ServerInterceptor(grpcext.UnaryServerInterceptor,
     self.intercepted = True
     return handler(request, servicer_context)
 
-  def intercept_stream(self, servicer_context, server_info, handler):
+  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
+                       handler):
     self.intercepted = True
-    return handler(servicer_context)
+    return handler(request_or_iterator, servicer_context)
 
 
 class InterceptorTest(unittest.TestCase):

--- a/python/tests/test_interceptor.py
+++ b/python/tests/test_interceptor.py
@@ -12,7 +12,7 @@ class ClientInterceptor(grpcext.UnaryClientInterceptor,
   def __init__(self):
     self.intercepted = False
 
-  def intercept_unary(self, method, request, metadata, invoker):
+  def intercept_unary(self, request, metadata, client_info, invoker):
     self.intercepted = True
     return invoker(request, metadata)
 

--- a/python/tests/test_interceptor.py
+++ b/python/tests/test_interceptor.py
@@ -9,155 +9,160 @@ from _service import Service
 class ClientInterceptor(grpcext.UnaryClientInterceptor,
                         grpcext.StreamClientInterceptor):
 
-  def __init__(self):
-    self.intercepted = False
+    def __init__(self):
+        self.intercepted = False
 
-  def intercept_unary(self, request, metadata, client_info, invoker):
-    self.intercepted = True
-    return invoker(request, metadata)
+    def intercept_unary(self, request, metadata, client_info, invoker):
+        self.intercepted = True
+        return invoker(request, metadata)
 
-  def intercept_stream(self, request_or_iterator, metadata, client_info,
-                       invoker):
-    self.intercepted = True
-    return invoker(request_or_iterator, metadata)
+    def intercept_stream(self, request_or_iterator, metadata, client_info,
+                         invoker):
+        self.intercepted = True
+        return invoker(request_or_iterator, metadata)
 
 
 class ServerInterceptor(grpcext.UnaryServerInterceptor,
                         grpcext.StreamServerInterceptor):
 
-  def __init__(self):
-    self.intercepted = False
+    def __init__(self):
+        self.intercepted = False
 
-  def intercept_unary(self, request, servicer_context, server_info, handler):
-    self.intercepted = True
-    return handler(request, servicer_context)
+    def intercept_unary(self, request, servicer_context, server_info, handler):
+        self.intercepted = True
+        return handler(request, servicer_context)
 
-  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
-                       handler):
-    self.intercepted = True
-    return handler(request_or_iterator, servicer_context)
+    def intercept_stream(self, request_or_iterator, servicer_context,
+                         server_info, handler):
+        self.intercepted = True
+        return handler(request_or_iterator, servicer_context)
 
 
 class InterceptorTest(unittest.TestCase):
-  """Test that RPC calls are intercepted."""
+    """Test that RPC calls are intercepted."""
 
-  def setUp(self):
-    self._client_interceptor = ClientInterceptor()
-    self._server_interceptor = ServerInterceptor()
-    self._service = Service([self._client_interceptor],
-                            [self._server_interceptor])
+    def setUp(self):
+        self._client_interceptor = ClientInterceptor()
+        self._server_interceptor = ServerInterceptor()
+        self._service = Service([self._client_interceptor],
+                                [self._server_interceptor])
 
-  def testUnaryUnaryInterception(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response = multi_callable(request)
+    def testUnaryUnaryInterception(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response = multi_callable(request)
 
-    self.assertEqual(response, expected_response)
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testUnaryUnaryInterceptionWithCall(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response, call = multi_callable.with_call(request)
+    def testUnaryUnaryInterceptionWithCall(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response, call = multi_callable.with_call(request)
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testUnaryUnaryInterceptionFuture(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response = multi_callable.future(request).result()
+    def testUnaryUnaryInterceptionFuture(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response = multi_callable.future(request).result()
 
-    self.assertEqual(response, expected_response)
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testUnaryStreamInterception(self):
-    multi_callable = self._service.unary_stream_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_stream(request, None)
-    response = multi_callable(request)
+    def testUnaryStreamInterception(self):
+        multi_callable = self._service.unary_stream_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_stream(request,
+                                                                      None)
+        response = multi_callable(request)
 
-    self.assertEqual(list(response), list(expected_response))
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(list(response), list(expected_response))
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testStreamUnaryInterception(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamUnaryInterception(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(response, expected_response)
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testStreamUnaryInterceptionWithCall(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response, call = multi_callable.with_call(iter(requests))
+    def testStreamUnaryInterceptionWithCall(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response, call = multi_callable.with_call(iter(requests))
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testStreamUnaryInterceptionFuture(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response = multi_callable.future(iter(requests)).result()
+    def testStreamUnaryInterceptionFuture(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response = multi_callable.future(iter(requests)).result()
 
-    self.assertEqual(response, expected_response)
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
-  def testStreamStreamInterception(self):
-    multi_callable = self._service.stream_stream_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_stream(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamStreamInterception(self):
+        multi_callable = self._service.stream_stream_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_stream(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(list(response), list(expected_response))
-    self.assertTrue(self._client_interceptor.intercepted)
-    self.assertTrue(self._server_interceptor.intercepted)
+        self.assertEqual(list(response), list(expected_response))
+        self.assertTrue(self._client_interceptor.intercepted)
+        self.assertTrue(self._server_interceptor.intercepted)
 
 
 class MultiInterceptorTest(unittest.TestCase):
-  """Test that you can chain multiple interceptors together."""
+    """Test that you can chain multiple interceptors together."""
 
-  def setUp(self):
-    self._client_interceptors = [ClientInterceptor(), ClientInterceptor()]
-    self._server_interceptors = [ServerInterceptor(), ServerInterceptor()]
-    self._service = Service(self._client_interceptors,
-                            self._server_interceptors)
+    def setUp(self):
+        self._client_interceptors = [ClientInterceptor(), ClientInterceptor()]
+        self._server_interceptors = [ServerInterceptor(), ServerInterceptor()]
+        self._service = Service(self._client_interceptors,
+                                self._server_interceptors)
 
-  def _clear(self):
-    for client_interceptor in self._client_interceptors:
-      client_interceptor.intercepted = False
+    def _clear(self):
+        for client_interceptor in self._client_interceptors:
+            client_interceptor.intercepted = False
 
-    for server_interceptor in self._server_interceptors:
-      server_interceptor.intercepted = False
+        for server_interceptor in self._server_interceptors:
+            server_interceptor.intercepted = False
 
-  def testUnaryUnaryMultiInterception(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response = multi_callable(request)
+    def testUnaryUnaryMultiInterception(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response = multi_callable(request)
 
-    self.assertEqual(response, expected_response)
-    for client_interceptor in self._client_interceptors:
-      self.assertTrue(client_interceptor.intercepted)
-    for server_interceptor in self._server_interceptors:
-      self.assertTrue(server_interceptor.intercepted)
+        self.assertEqual(response, expected_response)
+        for client_interceptor in self._client_interceptors:
+            self.assertTrue(client_interceptor.intercepted)
+        for server_interceptor in self._server_interceptors:
+            self.assertTrue(server_interceptor.intercepted)

--- a/python/tests/test_interceptor.py
+++ b/python/tests/test_interceptor.py
@@ -125,7 +125,7 @@ class InterceptorTest(unittest.TestCase):
   def testStreamStreamInterception(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -135,6 +135,214 @@ class OpenTracingTest(unittest.TestCase):
         self._tracer.get_relationship(0, 1), SpanRelationship.CHILD_OF)
 
 
+class OpenTracingInteroperabilityClientTest(unittest.TestCase):
+  """Test that a traced client can interoperate with a non-trace server."""
+
+  def setUp(self):
+    self._tracer = Tracer()
+    self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                            [])
+
+  def testUnaryUnaryOpenTracing(self):
+    multi_callable = self._service.unary_unary_multi_callable
+    request = b'\x01'
+    expected_response = self._service.handler.handle_unary_unary(request, None)
+    response = multi_callable(request)
+
+    self.assertEqual(response, expected_response)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'client')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testUnaryUnaryOpenTracingWithCall(self):
+    multi_callable = self._service.unary_unary_multi_callable
+    request = b'\x01'
+    expected_response = self._service.handler.handle_unary_unary(request, None)
+    response, call = multi_callable.with_call(request)
+
+    self.assertEqual(response, expected_response)
+    self.assertIs(grpc.StatusCode.OK, call.code())
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'client')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testUnaryStreamOpenTracing(self):
+    multi_callable = self._service.unary_stream_multi_callable
+    request = b'\x01'
+    expected_response = self._service.handler.handle_unary_stream(request, None)
+    response = multi_callable(request)
+
+    self.assertEqual(list(response), list(expected_response))
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'client')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testStreamUnaryOpenTracing(self):
+    multi_callable = self._service.stream_unary_multi_callable
+    requests = [b'\x01', b'\x02']
+    expected_response = self._service.handler.handle_stream_unary(
+        iter(requests), None)
+    response = multi_callable(iter(requests))
+
+    self.assertEqual(response, expected_response)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'client')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testStreamUnaryOpenTracingWithCall(self):
+    multi_callable = self._service.stream_unary_multi_callable
+    requests = [b'\x01', b'\x02']
+    expected_response = self._service.handler.handle_stream_unary(
+        iter(requests), None)
+    response, call = multi_callable.with_call(iter(requests))
+
+    self.assertEqual(response, expected_response)
+    self.assertIs(grpc.StatusCode.OK, call.code())
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'client')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testStreamStreamOpenTracing(self):
+    multi_callable = self._service.stream_stream_multi_callable
+    requests = [b'\x01', b'\x02']
+    expected_response = self._service.handler.handle_stream_unary(
+        iter(requests), None)
+    response = multi_callable(iter(requests))
+
+    self.assertEqual(list(response), list(expected_response))
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'client')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+
+class OpenTracingInteroperabilityServerTest(unittest.TestCase):
+  """Test that a traced server can interoperate with a non-trace client."""
+
+  def setUp(self):
+    self._tracer = Tracer()
+    self._service = Service([],
+                            [open_tracing_server_interceptor(self._tracer)])
+
+  def testUnaryUnaryOpenTracing(self):
+    multi_callable = self._service.unary_unary_multi_callable
+    request = b'\x01'
+    expected_response = self._service.handler.handle_unary_unary(request, None)
+    response = multi_callable(request)
+
+    self.assertEqual(response, expected_response)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'server')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testUnaryUnaryOpenTracingWithCall(self):
+    multi_callable = self._service.unary_unary_multi_callable
+    request = b'\x01'
+    expected_response = self._service.handler.handle_unary_unary(request, None)
+    response, call = multi_callable.with_call(request)
+
+    self.assertEqual(response, expected_response)
+    self.assertIs(grpc.StatusCode.OK, call.code())
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'server')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testUnaryStreamOpenTracing(self):
+    multi_callable = self._service.unary_stream_multi_callable
+    request = b'\x01'
+    expected_response = self._service.handler.handle_unary_stream(request, None)
+    response = multi_callable(request)
+
+    self.assertEqual(list(response), list(expected_response))
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'server')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testStreamUnaryOpenTracing(self):
+    multi_callable = self._service.stream_unary_multi_callable
+    requests = [b'\x01', b'\x02']
+    expected_response = self._service.handler.handle_stream_unary(
+        iter(requests), None)
+    response = multi_callable(iter(requests))
+
+    self.assertEqual(response, expected_response)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'server')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testStreamUnaryOpenTracingWithCall(self):
+    multi_callable = self._service.stream_unary_multi_callable
+    requests = [b'\x01', b'\x02']
+    expected_response = self._service.handler.handle_stream_unary(
+        iter(requests), None)
+    response, call = multi_callable.with_call(iter(requests))
+
+    self.assertEqual(response, expected_response)
+    self.assertIs(grpc.StatusCode.OK, call.code())
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'server')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+  def testStreamStreamOpenTracing(self):
+    multi_callable = self._service.stream_stream_multi_callable
+    requests = [b'\x01', b'\x02']
+    expected_response = self._service.handler.handle_stream_unary(
+        iter(requests), None)
+    response = multi_callable(iter(requests))
+
+    self.assertEqual(list(response), list(expected_response))
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertEqual(span0.get_tag('span.kind'), 'server')
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNone(span1)
+
+
 class OpenTracingErroringTest(unittest.TestCase):
   """Test that tracer spans set the error tag when erroring RPC are invoked."""
 

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -59,14 +59,6 @@ class OpenTracingTest(unittest.TestCase):
             self._tracer.get_relationship(0, 1),
             opentracing.ReferenceType.CHILD_OF)
 
-        span2 = self._tracer.get_span(2)
-        self.assertIsNotNone(span2)
-        self.assertTrue(span2.get_tag('span.kind'), 'client')
-
-        self.assertEqual(
-            self._tracer.get_relationship(1, 2),
-            opentracing.ReferenceType.FOLLOWS_FROM)
-
     def testUnaryUnaryOpenTracingWithCall(self):
         multi_callable = self._service.unary_unary_multi_callable
         request = b'\x01'
@@ -174,14 +166,6 @@ class OpenTracingTest(unittest.TestCase):
         self.assertEqual(
             self._tracer.get_relationship(0, 1),
             opentracing.ReferenceType.CHILD_OF)
-
-        span2 = self._tracer.get_span(2)
-        self.assertIsNotNone(span2)
-        self.assertTrue(span2.get_tag('span.kind'), 'client')
-
-        self.assertEqual(
-            self._tracer.get_relationship(1, 2),
-            opentracing.ReferenceType.FOLLOWS_FROM)
 
     def testStreamStreamOpenTracing(self):
         multi_callable = self._service.stream_stream_multi_callable

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -155,8 +155,7 @@ class OpenTracingErroringTest(unittest.TestCase):
 
     span1 = self._tracer.get_span(1)
     self.assertIsNotNone(span1)
-    # TODO
-    # self.assertTrue(span1.get_tag('error'))
+    self.assertTrue(span1.get_tag('error'))
 
   def testUnaryUnaryOpenTracingWithCall(self):
     multi_callable = self._service.unary_unary_multi_callable
@@ -169,8 +168,7 @@ class OpenTracingErroringTest(unittest.TestCase):
 
     span1 = self._tracer.get_span(1)
     self.assertIsNotNone(span1)
-    # TODO
-    # self.assertTrue(span1.get_tag('error'))
+    self.assertTrue(span1.get_tag('error'))
 
   def testUnaryStreamOpenTracing(self):
     multi_callable = self._service.unary_stream_multi_callable
@@ -184,8 +182,7 @@ class OpenTracingErroringTest(unittest.TestCase):
 
     span1 = self._tracer.get_span(1)
     self.assertIsNotNone(span1)
-    # TODO
-    # self.assertTrue(span1.get_tag('error'))
+    self.assertTrue(span1.get_tag('error'))
 
   def testStreamUnaryOpenTracing(self):
     multi_callable = self._service.stream_unary_multi_callable
@@ -198,8 +195,7 @@ class OpenTracingErroringTest(unittest.TestCase):
 
     span1 = self._tracer.get_span(1)
     self.assertIsNotNone(span1)
-    # TODO
-    # self.assertTrue(span1.get_tag('error'))
+    self.assertTrue(span1.get_tag('error'))
 
   def testStreamUnaryOpenTracingWithCall(self):
     multi_callable = self._service.stream_unary_multi_callable
@@ -212,8 +208,7 @@ class OpenTracingErroringTest(unittest.TestCase):
 
     span1 = self._tracer.get_span(1)
     self.assertIsNotNone(span1)
-    # TODO
-    # self.assertTrue(span1.get_tag('error'))
+    self.assertTrue(span1.get_tag('error'))
 
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
@@ -227,5 +222,4 @@ class OpenTracingErroringTest(unittest.TestCase):
 
     span1 = self._tracer.get_span(1)
     self.assertIsNotNone(span1)
-    # TODO
-    # self.assertTrue(span1.get_tag('error'))
+    self.assertTrue(span1.get_tag('error'))

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -9,597 +9,619 @@ import opentracing
 
 
 class OpenTracingTest(unittest.TestCase):
-  """Test that tracers create the correct spans when RPC calls are invoked."""
+    """Test that tracers create the correct spans when RPC calls are invoked."""
 
-  def setUp(self):
-    self._tracer = Tracer()
-    self._service = Service([open_tracing_client_interceptor(self._tracer)],
-                            [open_tracing_server_interceptor(self._tracer)])
+    def setUp(self):
+        self._tracer = Tracer()
+        self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                                [open_tracing_server_interceptor(self._tracer)])
 
-  def testUnaryUnaryOpenTracing(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response = multi_callable(request)
+    def testUnaryUnaryOpenTracing(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response = multi_callable(request)
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-  def testUnaryUnaryOpenTracingFuture(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    future = multi_callable.future(request)
-    response = future.result()
+    def testUnaryUnaryOpenTracingFuture(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        future = multi_callable.future(request)
+        response = future.result()
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-    span2 = self._tracer.get_span(2)
-    self.assertIsNotNone(span2)
-    self.assertTrue(span2.get_tag('span.kind'), 'client')
+        span2 = self._tracer.get_span(2)
+        self.assertIsNotNone(span2)
+        self.assertTrue(span2.get_tag('span.kind'), 'client')
 
-    self.assertEqual(
-        self._tracer.get_relationship(1, 2),
-        opentracing.ReferenceType.FOLLOWS_FROM)
+        self.assertEqual(
+            self._tracer.get_relationship(1, 2),
+            opentracing.ReferenceType.FOLLOWS_FROM)
 
-  def testUnaryUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response, call = multi_callable.with_call(request)
+    def testUnaryUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response, call = multi_callable.with_call(request)
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-  def testUnaryStreamOpenTracing(self):
-    multi_callable = self._service.unary_stream_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_stream(request, None)
-    response = multi_callable(request)
+    def testUnaryStreamOpenTracing(self):
+        multi_callable = self._service.unary_stream_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_stream(request,
+                                                                      None)
+        response = multi_callable(request)
 
-    self.assertEqual(list(response), list(expected_response))
+        self.assertEqual(list(response), list(expected_response))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-  def testStreamUnaryOpenTracing(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamUnaryOpenTracing(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-  def testStreamUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response, call = multi_callable.with_call(iter(requests))
+    def testStreamUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response, call = multi_callable.with_call(iter(requests))
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-  def testStreamUnaryOpenTracingFuture(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    result = multi_callable.future(iter(requests))
-    response = result.result()
+    def testStreamUnaryOpenTracingFuture(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        result = multi_callable.future(iter(requests))
+        response = result.result()
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
-    span2 = self._tracer.get_span(2)
-    self.assertIsNotNone(span2)
-    self.assertTrue(span2.get_tag('span.kind'), 'client')
+        span2 = self._tracer.get_span(2)
+        self.assertIsNotNone(span2)
+        self.assertTrue(span2.get_tag('span.kind'), 'client')
 
-    self.assertEqual(
-        self._tracer.get_relationship(1, 2),
-        opentracing.ReferenceType.FOLLOWS_FROM)
+        self.assertEqual(
+            self._tracer.get_relationship(1, 2),
+            opentracing.ReferenceType.FOLLOWS_FROM)
 
-  def testStreamStreamOpenTracing(self):
-    multi_callable = self._service.stream_stream_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_stream(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamStreamOpenTracing(self):
+        multi_callable = self._service.stream_stream_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_stream(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(list(response), list(expected_response))
+        self.assertEqual(list(response), list(expected_response))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertEqual(span1.get_tag('span.kind'), 'server')
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertEqual(span1.get_tag('span.kind'), 'server')
 
-    self.assertEqual(
-        self._tracer.get_relationship(0, 1), opentracing.ReferenceType.CHILD_OF)
+        self.assertEqual(
+            self._tracer.get_relationship(0, 1),
+            opentracing.ReferenceType.CHILD_OF)
 
 
 class OpenTracingInteroperabilityClientTest(unittest.TestCase):
-  """Test that a traced client can interoperate with a non-trace server."""
+    """Test that a traced client can interoperate with a non-trace server."""
 
-  def setUp(self):
-    self._tracer = Tracer()
-    self._service = Service([open_tracing_client_interceptor(self._tracer)], [])
+    def setUp(self):
+        self._tracer = Tracer()
+        self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                                [])
 
-  def testUnaryUnaryOpenTracing(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response = multi_callable(request)
+    def testUnaryUnaryOpenTracing(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response = multi_callable(request)
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testUnaryUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response, call = multi_callable.with_call(request)
+    def testUnaryUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response, call = multi_callable.with_call(request)
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testUnaryStreamOpenTracing(self):
-    multi_callable = self._service.unary_stream_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_stream(request, None)
-    response = multi_callable(request)
+    def testUnaryStreamOpenTracing(self):
+        multi_callable = self._service.unary_stream_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_stream(request,
+                                                                      None)
+        response = multi_callable(request)
 
-    self.assertEqual(list(response), list(expected_response))
+        self.assertEqual(list(response), list(expected_response))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testStreamUnaryOpenTracing(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamUnaryOpenTracing(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testStreamUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response, call = multi_callable.with_call(iter(requests))
+    def testStreamUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response, call = multi_callable.with_call(iter(requests))
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testStreamStreamOpenTracing(self):
-    multi_callable = self._service.stream_stream_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_stream(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamStreamOpenTracing(self):
+        multi_callable = self._service.stream_stream_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_stream(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(list(response), list(expected_response))
+        self.assertEqual(list(response), list(expected_response))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'client')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'client')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
 
 class OpenTracingMetadataTest(unittest.TestCase):
-  """Test that open-tracing doesn't interfere with passing metadata through the
+    """Test that open-tracing doesn't interfere with passing metadata through the
     RPC.
   """
 
-  def setUp(self):
-    self._tracer = Tracer()
-    self._service = Service([open_tracing_client_interceptor(self._tracer)],
-                            [open_tracing_server_interceptor(self._tracer)])
+    def setUp(self):
+        self._tracer = Tracer()
+        self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                                [open_tracing_server_interceptor(self._tracer)])
 
-  def testInvocationMetadata(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    multi_callable(request, None, (('abc', '123'),))
-    self.assertIn(('abc', '123'), self._service.handler.invocation_metadata)
+    def testInvocationMetadata(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        multi_callable(request, None, (('abc', '123'),))
+        self.assertIn(('abc', '123'), self._service.handler.invocation_metadata)
 
-  def testTrailingMetadata(self):
-    self._service.handler.trailing_metadata = (('abc', '123'),)
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    future = multi_callable.future(request, None, (('abc', '123'),))
-    self.assertIn(('abc', '123'), future.trailing_metadata())
+    def testTrailingMetadata(self):
+        self._service.handler.trailing_metadata = (('abc', '123'),)
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        future = multi_callable.future(request, None, (('abc', '123'),))
+        self.assertIn(('abc', '123'), future.trailing_metadata())
 
 
 class OpenTracingInteroperabilityServerTest(unittest.TestCase):
-  """Test that a traced server can interoperate with a non-trace client."""
+    """Test that a traced server can interoperate with a non-trace client."""
 
-  def setUp(self):
-    self._tracer = Tracer()
-    self._service = Service([], [open_tracing_server_interceptor(self._tracer)])
+    def setUp(self):
+        self._tracer = Tracer()
+        self._service = Service([],
+                                [open_tracing_server_interceptor(self._tracer)])
 
-  def testUnaryUnaryOpenTracing(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response = multi_callable(request)
+    def testUnaryUnaryOpenTracing(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response = multi_callable(request)
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'server')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'server')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testUnaryUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_unary(request, None)
-    response, call = multi_callable.with_call(request)
+    def testUnaryUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_unary(request,
+                                                                     None)
+        response, call = multi_callable.with_call(request)
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'server')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'server')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testUnaryStreamOpenTracing(self):
-    multi_callable = self._service.unary_stream_multi_callable
-    request = b'\x01'
-    expected_response = self._service.handler.handle_unary_stream(request, None)
-    response = multi_callable(request)
+    def testUnaryStreamOpenTracing(self):
+        multi_callable = self._service.unary_stream_multi_callable
+        request = b'\x01'
+        expected_response = self._service.handler.handle_unary_stream(request,
+                                                                      None)
+        response = multi_callable(request)
 
-    self.assertEqual(list(response), list(expected_response))
+        self.assertEqual(list(response), list(expected_response))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'server')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'server')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testStreamUnaryOpenTracing(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamUnaryOpenTracing(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(response, expected_response)
+        self.assertEqual(response, expected_response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'server')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'server')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testStreamUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
-        iter(requests), None)
-    response, call = multi_callable.with_call(iter(requests))
+    def testStreamUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_unary(
+            iter(requests), None)
+        response, call = multi_callable.with_call(iter(requests))
 
-    self.assertEqual(response, expected_response)
-    self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual(response, expected_response)
+        self.assertIs(grpc.StatusCode.OK, call.code())
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'server')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'server')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
-  def testStreamStreamOpenTracing(self):
-    multi_callable = self._service.stream_stream_multi_callable
-    requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_stream(
-        iter(requests), None)
-    response = multi_callable(iter(requests))
+    def testStreamStreamOpenTracing(self):
+        multi_callable = self._service.stream_stream_multi_callable
+        requests = [b'\x01', b'\x02']
+        expected_response = self._service.handler.handle_stream_stream(
+            iter(requests), None)
+        response = multi_callable(iter(requests))
 
-    self.assertEqual(list(response), list(expected_response))
+        self.assertEqual(list(response), list(expected_response))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertEqual(span0.get_tag('span.kind'), 'server')
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertEqual(span0.get_tag('span.kind'), 'server')
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNone(span1)
+        span1 = self._tracer.get_span(1)
+        self.assertIsNone(span1)
 
 
 class OpenTracingErroringTest(unittest.TestCase):
-  """Test that tracer spans set the error tag when erroring RPC are invoked."""
+    """Test that tracer spans set the error tag when erroring RPC are invoked."""
 
-  def setUp(self):
-    self._tracer = Tracer()
-    self._service = Service([open_tracing_client_interceptor(self._tracer)],
-                            [open_tracing_server_interceptor(self._tracer)],
-                            ErroringHandler())
+    def setUp(self):
+        self._tracer = Tracer()
+        self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                                [open_tracing_server_interceptor(self._tracer)],
+                                ErroringHandler())
 
-  def testUnaryUnaryOpenTracing(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    self.assertRaises(grpc.RpcError, multi_callable, request)
+    def testUnaryUnaryOpenTracing(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        self.assertRaises(grpc.RpcError, multi_callable, request)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testUnaryUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    self.assertRaises(grpc.RpcError, multi_callable.with_call, request)
+    def testUnaryUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        self.assertRaises(grpc.RpcError, multi_callable.with_call, request)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testUnaryStreamOpenTracing(self):
-    multi_callable = self._service.unary_stream_multi_callable
-    request = b'\x01'
-    response = multi_callable(request)
-    self.assertRaises(grpc.RpcError, list, response)
+    def testUnaryStreamOpenTracing(self):
+        multi_callable = self._service.unary_stream_multi_callable
+        request = b'\x01'
+        response = multi_callable(request)
+        self.assertRaises(grpc.RpcError, list, response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testStreamUnaryOpenTracing(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    self.assertRaises(grpc.RpcError, multi_callable, iter(requests))
+    def testStreamUnaryOpenTracing(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        self.assertRaises(grpc.RpcError, multi_callable, iter(requests))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testStreamUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    self.assertRaises(grpc.RpcError, multi_callable.with_call, iter(requests))
+    def testStreamUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        self.assertRaises(grpc.RpcError, multi_callable.with_call,
+                          iter(requests))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testStreamStreamOpenTracing(self):
-    multi_callable = self._service.stream_stream_multi_callable
-    requests = [b'\x01', b'\x02']
-    response = multi_callable(iter(requests))
-    self.assertRaises(grpc.RpcError, list, response)
+    def testStreamStreamOpenTracing(self):
+        multi_callable = self._service.stream_stream_multi_callable
+        requests = [b'\x01', b'\x02']
+        response = multi_callable(iter(requests))
+        self.assertRaises(grpc.RpcError, list, response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
 
 class OpenTracingExceptionErroringTest(unittest.TestCase):
-  """Test that tracer spans set the error tag when exception erroring RPC are 
+    """Test that tracer spans set the error tag when exception erroring RPC are 
     invoked.
   """
 
-  def setUp(self):
-    self._tracer = Tracer()
-    self._service = Service([open_tracing_client_interceptor(self._tracer)],
-                            [open_tracing_server_interceptor(self._tracer)],
-                            ExceptionErroringHandler())
+    def setUp(self):
+        self._tracer = Tracer()
+        self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                                [open_tracing_server_interceptor(self._tracer)],
+                                ExceptionErroringHandler())
 
-  def testUnaryUnaryOpenTracing(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    self.assertRaises(grpc.RpcError, multi_callable, request)
+    def testUnaryUnaryOpenTracing(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        self.assertRaises(grpc.RpcError, multi_callable, request)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testUnaryUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.unary_unary_multi_callable
-    request = b'\x01'
-    self.assertRaises(grpc.RpcError, multi_callable.with_call, request)
+    def testUnaryUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.unary_unary_multi_callable
+        request = b'\x01'
+        self.assertRaises(grpc.RpcError, multi_callable.with_call, request)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testUnaryStreamOpenTracing(self):
-    multi_callable = self._service.unary_stream_multi_callable
-    request = b'\x01'
-    response = multi_callable(request)
-    self.assertRaises(grpc.RpcError, list, response)
+    def testUnaryStreamOpenTracing(self):
+        multi_callable = self._service.unary_stream_multi_callable
+        request = b'\x01'
+        response = multi_callable(request)
+        self.assertRaises(grpc.RpcError, list, response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testStreamUnaryOpenTracing(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    self.assertRaises(grpc.RpcError, multi_callable, iter(requests))
+    def testStreamUnaryOpenTracing(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        self.assertRaises(grpc.RpcError, multi_callable, iter(requests))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testStreamUnaryOpenTracingWithCall(self):
-    multi_callable = self._service.stream_unary_multi_callable
-    requests = [b'\x01', b'\x02']
-    self.assertRaises(grpc.RpcError, multi_callable.with_call, iter(requests))
+    def testStreamUnaryOpenTracingWithCall(self):
+        multi_callable = self._service.stream_unary_multi_callable
+        requests = [b'\x01', b'\x02']
+        self.assertRaises(grpc.RpcError, multi_callable.with_call,
+                          iter(requests))
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))
 
-  def testStreamStreamOpenTracing(self):
-    multi_callable = self._service.stream_stream_multi_callable
-    requests = [b'\x01', b'\x02']
-    response = multi_callable(iter(requests))
-    self.assertRaises(grpc.RpcError, list, response)
+    def testStreamStreamOpenTracing(self):
+        multi_callable = self._service.stream_stream_multi_callable
+        requests = [b'\x01', b'\x02']
+        response = multi_callable(iter(requests))
+        self.assertRaises(grpc.RpcError, list, response)
 
-    span0 = self._tracer.get_span(0)
-    self.assertIsNotNone(span0)
-    self.assertTrue(span0.get_tag('error'))
+        span0 = self._tracer.get_span(0)
+        self.assertIsNotNone(span0)
+        self.assertTrue(span0.get_tag('error'))
 
-    span1 = self._tracer.get_span(1)
-    self.assertIsNotNone(span1)
-    self.assertTrue(span1.get_tag('error'))
+        span1 = self._tracer.get_span(1)
+        self.assertIsNotNone(span1)
+        self.assertTrue(span1.get_tag('error'))

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -175,7 +175,7 @@ class OpenTracingTest(unittest.TestCase):
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 
@@ -282,7 +282,7 @@ class OpenTracingInteroperabilityClientTest(unittest.TestCase):
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 
@@ -409,7 +409,7 @@ class OpenTracingInteroperabilityServerTest(unittest.TestCase):
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -2,7 +2,7 @@ import unittest
 
 import grpc
 
-from _service import Service, ErroringHandler
+from _service import Service, ErroringHandler, ExceptionErroringHandler
 from _tracer import Tracer, SpanRelationship
 from grpc_opentracing import open_tracing_client_interceptor, open_tracing_server_interceptor
 
@@ -143,6 +143,98 @@ class OpenTracingErroringTest(unittest.TestCase):
     self._service = Service([open_tracing_client_interceptor(self._tracer)],
                             [open_tracing_server_interceptor(self._tracer)],
                             ErroringHandler())
+
+  def testUnaryUnaryOpenTracing(self):
+    multi_callable = self._service.unary_unary_multi_callable
+    request = b'\x01'
+    self.assertRaises(grpc.RpcError, multi_callable, request)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertTrue(span0.get_tag('error'))
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNotNone(span1)
+    self.assertTrue(span1.get_tag('error'))
+
+  def testUnaryUnaryOpenTracingWithCall(self):
+    multi_callable = self._service.unary_unary_multi_callable
+    request = b'\x01'
+    self.assertRaises(grpc.RpcError, multi_callable.with_call, request)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertTrue(span0.get_tag('error'))
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNotNone(span1)
+    self.assertTrue(span1.get_tag('error'))
+
+  def testUnaryStreamOpenTracing(self):
+    multi_callable = self._service.unary_stream_multi_callable
+    request = b'\x01'
+    response = multi_callable(request)
+    self.assertRaises(grpc.RpcError, list, response)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertTrue(span0.get_tag('error'))
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNotNone(span1)
+    self.assertTrue(span1.get_tag('error'))
+
+  def testStreamUnaryOpenTracing(self):
+    multi_callable = self._service.stream_unary_multi_callable
+    requests = [b'\x01', b'\x02']
+    self.assertRaises(grpc.RpcError, multi_callable, iter(requests))
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertTrue(span0.get_tag('error'))
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNotNone(span1)
+    self.assertTrue(span1.get_tag('error'))
+
+  def testStreamUnaryOpenTracingWithCall(self):
+    multi_callable = self._service.stream_unary_multi_callable
+    requests = [b'\x01', b'\x02']
+    self.assertRaises(grpc.RpcError, multi_callable.with_call, iter(requests))
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertTrue(span0.get_tag('error'))
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNotNone(span1)
+    self.assertTrue(span1.get_tag('error'))
+
+  def testStreamStreamOpenTracing(self):
+    multi_callable = self._service.stream_stream_multi_callable
+    requests = [b'\x01', b'\x02']
+    response = multi_callable(iter(requests))
+    self.assertRaises(grpc.RpcError, list, response)
+
+    span0 = self._tracer.get_span(0)
+    self.assertIsNotNone(span0)
+    self.assertTrue(span0.get_tag('error'))
+
+    span1 = self._tracer.get_span(1)
+    self.assertIsNotNone(span1)
+    self.assertTrue(span1.get_tag('error'))
+
+
+class OpenTracingExceptionErroringTest(unittest.TestCase):
+  """Test that tracer spans set the error tag when exception erroring RPC are 
+    invoked.
+  """
+
+  def setUp(self):
+    self._tracer = Tracer()
+    self._service = Service([open_tracing_client_interceptor(self._tracer)],
+                            [open_tracing_server_interceptor(self._tracer)],
+                            ExceptionErroringHandler())
 
   def testUnaryUnaryOpenTracing(self):
     multi_callable = self._service.unary_unary_multi_callable


### PR DESCRIPTION
1. Ported grpc tags in Java code.
2. Changed interceptor API to make the `timeout` available to interceptors.
3. Fixed an issue with reporting errors via status from the server-side.
4. Added test coverage for interoperability, metadata, and async RPCs.