### PR TITLE
Add message logging to streaming RPCs.

### DIFF
--- a/python/examples/store/store_client.py
+++ b/python/examples/store/store_client.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import sys
 import argparse
-from builtins import input
+from builtins import input, range
 
 import grpc
 import lightstep
@@ -97,7 +97,7 @@ class CommandExecuter(object):
 def execute_command(command_executer, command, arguments):
   via = 'functor'
   timeout = None
-  for argument_index in xrange(0, len(arguments), 2):
+  for argument_index in range(0, len(arguments), 2):
     argument = arguments[argument_index]
     if argument == '--via' and argument_index + 1 < len(arguments):
       if via not in ('functor', 'with_call', 'future'):

--- a/python/grpc_opentracing/_server.py
+++ b/python/grpc_opentracing/_server.py
@@ -180,12 +180,13 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
   # For RPCs that stream responses, the result can be a generator. To record
   # the span across the generated responses and detect any errors, we wrap the
   # result in a new generator that yields the response values.
-  def _intercept_server_stream(self, servicer_context, server_info, handler):
+  def _intercept_server_stream(self, request_or_iterator, servicer_context,
+                               server_info, handler):
     with self._start_span(servicer_context, server_info.full_method,
                           server_info.is_client_stream, True) as span:
       servicer_context = _OpenTracingServicerContext(servicer_context, span)
       try:
-        result = handler(servicer_context)
+        result = handler(request_or_iterator, servicer_context)
         for response in result:
           yield response
       except:
@@ -195,10 +196,11 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
         raise
       _check_error_code(span, servicer_context)
 
-  def intercept_stream(self, servicer_context, server_info, handler):
+  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
+                       handler):
     if server_info.is_server_stream:
-      return self._intercept_server_stream(servicer_context, server_info,
-                                           handler)
+      return self._intercept_server_stream(
+          request_or_iterator, servicer_context, server_info, handler)
     with self._start_span(servicer_context, server_info.full_method,
                           server_info.is_client_stream, False) as span:
       # The invocation-side may have invoked this RPC asynchronously; in which
@@ -209,7 +211,7 @@ class OpenTracingServerInterceptor(grpcext.UnaryServerInterceptor,
       servicer_context = _OpenTracingServicerContext(servicer_context, span,
                                                      trailing_metadata)
       try:
-        result = handler(servicer_context)
+        result = handler(request_or_iterator, servicer_context)
       except:
         e = sys.exc_info()[0]
         span.set_tag('error', True)

--- a/python/grpc_opentracing/grpcext/__init__.py
+++ b/python/grpc_opentracing/grpcext/__init__.py
@@ -60,11 +60,15 @@ class StreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
   """
 
   @abc.abstractmethod
-  def intercept_stream(self, metadata, client_info, invoker):
+  def intercept_stream(self, request_or_iterator, metadata, client_info,
+                       invoker):
     """A function to be called when an invocation-side, unary-stream,
       stream-unary, or stream-stream RPC method is invoked.
 
     Args:
+      request_or_iterator: The request value for the RPC if
+        `client_info.is_client_stream` is `false`; otherwise, an iterator of
+        request values.
       metadata: Optional :term:`metadata` to be transmitted to the service-side
         of the RPC.
       client_info: A StreamClientInfo containing various information about
@@ -145,11 +149,15 @@ class StreamServerInterceptor(six.with_metaclass(abc.ABCMeta)):
   """
 
   @abc.abstractmethod
-  def intercept_stream(self, servicer_context, server_info, handler):
+  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
+                       handler):
     """A function to be called when a service-side, unary-stream,
       stream-unary, or stream-stream RPC method is invoked.
 
     Args:
+      request_or_iterator: The request value for the RPC if
+        `server_info.is_client_stream` is `false`; otherwise, an iterator of
+        request values.
       servicer_context: A ServicerContext.
       server_info: A StreamServerInfo containing various information about
         the RPC.

--- a/python/grpc_opentracing/grpcext/_interceptor.py
+++ b/python/grpc_opentracing/grpcext/_interceptor.py
@@ -62,11 +62,12 @@ class _InterceptorUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
 
   def __call__(self, request, timeout=None, metadata=None, credentials=None):
 
-    def invoker(metadata):
+    def invoker(request, metadata):
       return self._base_callable(request, timeout, metadata, credentials)
 
     client_info = _StreamClientInfo(self._method, False, True, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request, metadata, client_info,
+                                              invoker)
 
 
 class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
@@ -82,12 +83,13 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                metadata=None,
                credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable(request_iterator, timeout, metadata,
                                  credentials)
 
     client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
   def with_call(self,
                 request_iterator,
@@ -95,12 +97,13 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                 metadata=None,
                 credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable.with_call(request_iterator, timeout, metadata,
                                            credentials)
 
     client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
   def future(self,
              request_iterator,
@@ -108,12 +111,13 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
              metadata=None,
              credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable.future(request_iterator, timeout, metadata,
                                         credentials)
 
     client_info = _StreamClientInfo(self._method, True, False, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
 
 class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
@@ -129,12 +133,13 @@ class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
                metadata=None,
                credentials=None):
 
-    def invoker(metadata):
+    def invoker(request_iterator, metadata):
       return self._base_callable(request_iterator, timeout, metadata,
                                  credentials)
 
     client_info = _StreamClientInfo(self._method, True, True, timeout)
-    return self._interceptor.intercept_stream(metadata, client_info, invoker)
+    return self._interceptor.intercept_stream(request_iterator, metadata,
+                                              client_info, invoker)
 
 
 class _InterceptorChannel(grpc.Channel):
@@ -267,11 +272,11 @@ class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
     def adaptation(request, servicer_context):
 
-      def handler(servicer_context):
+      def handler(request, servicer_context):
         return self._rpc_method_handler.unary_stream(request, servicer_context)
 
       return self._interceptor.intercept_stream(
-          servicer_context,
+          request, servicer_context,
           _StreamServerInfo(self._method, False, True), handler)
 
     return adaptation
@@ -283,12 +288,12 @@ class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
     def adaptation(request_iterator, servicer_context):
 
-      def handler(servicer_context):
+      def handler(request_iterator, servicer_context):
         return self._rpc_method_handler.stream_unary(request_iterator,
                                                      servicer_context)
 
       return self._interceptor.intercept_stream(
-          servicer_context,
+          request_iterator, servicer_context,
           _StreamServerInfo(self._method, True, False), handler)
 
     return adaptation
@@ -300,13 +305,13 @@ class _InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
 
     def adaptation(request_iterator, servicer_context):
 
-      def handler(servicer_context):
+      def handler(request_iterator, servicer_context):
         return self._rpc_method_handler.stream_stream(request_iterator,
                                                       servicer_context)
 
       return self._interceptor.intercept_stream(
-          servicer_context, _StreamServerInfo(self._method, True, True),
-          handler)
+          request_iterator, servicer_context,
+          _StreamServerInfo(self._method, True, True), handler)
 
     return adaptation
 

--- a/python/tests/_service.py
+++ b/python/tests/_service.py
@@ -1,5 +1,7 @@
 """Creates a simple service on top of gRPC for testing."""
 
+from builtins import input, range
+
 import grpc
 from grpc.framework.foundation import logging_pool
 from grpc_opentracing import grpcext
@@ -54,7 +56,7 @@ class Handler(object):
       self.invocation_metadata = servicer_context.invocation_metadata()
       if self.trailing_metadata is not None:
         servicer_context.set_trailing_metadata(self.trailing_metadata)
-    for _ in xrange(_STREAM_LENGTH):
+    for _ in range(_STREAM_LENGTH):
       yield request
 
   def handle_stream_unary(self, request_iterator, servicer_context):

--- a/python/tests/test_interceptor.py
+++ b/python/tests/test_interceptor.py
@@ -16,9 +16,10 @@ class ClientInterceptor(grpcext.UnaryClientInterceptor,
     self.intercepted = True
     return invoker(request, metadata)
 
-  def intercept_stream(self, metadata, client_info, invoker):
+  def intercept_stream(self, request_or_iterator, metadata, client_info,
+                       invoker):
     self.intercepted = True
-    return invoker(metadata)
+    return invoker(request_or_iterator, metadata)
 
 
 class ServerInterceptor(grpcext.UnaryServerInterceptor,
@@ -31,9 +32,10 @@ class ServerInterceptor(grpcext.UnaryServerInterceptor,
     self.intercepted = True
     return handler(request, servicer_context)
 
-  def intercept_stream(self, servicer_context, server_info, handler):
+  def intercept_stream(self, request_or_iterator, servicer_context, server_info,
+                       handler):
     self.intercepted = True
-    return handler(servicer_context)
+    return handler(request_or_iterator, servicer_context)
 
 
 class InterceptorTest(unittest.TestCase):

--- a/python/tests/test_interceptor.py
+++ b/python/tests/test_interceptor.py
@@ -125,7 +125,7 @@ class InterceptorTest(unittest.TestCase):
   def testStreamStreamInterception(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 

--- a/python/tests/test_opentracing.py
+++ b/python/tests/test_opentracing.py
@@ -175,7 +175,7 @@ class OpenTracingTest(unittest.TestCase):
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 
@@ -282,7 +282,7 @@ class OpenTracingInteroperabilityClientTest(unittest.TestCase):
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 
@@ -409,7 +409,7 @@ class OpenTracingInteroperabilityServerTest(unittest.TestCase):
   def testStreamStreamOpenTracing(self):
     multi_callable = self._service.stream_stream_multi_callable
     requests = [b'\x01', b'\x02']
-    expected_response = self._service.handler.handle_stream_unary(
+    expected_response = self._service.handler.handle_stream_stream(
         iter(requests), None)
     response = multi_callable(iter(requests))
 


### PR DESCRIPTION
This PR adds support for logging messages to streaming RPCs where possible. The one case that isn't logged are calls that stream requests, but take a unary response; in this case, if the RPC is invoked asynchronously then the span will be finished before the requests are iterated over, so they can't be logged to the span.